### PR TITLE
package.json: Added "engines" and "engineStrict"

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   ],
   "author": "John Babak <babak.john@gmail.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=0.12"
+  },
+  "engineStrict": true,
   "dependencies": {
     "chalk": "^1.0.0",
     "recast": "^0.10.4",


### PR DESCRIPTION
The `script.runInContext` fails to run with the provided context on
`node v0.10.33` but succeeds on `node v0.12.0` (a ReferenceError is
thrown for a variable that is present in the context).
