### PR TITLE
More examples, extended HTTP client to send custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ npm start
 ```
 The command prompt `KnowSheet> ` will appear.
 
-... or evaluate one expression from the command-line.
+... or evaluate one expression from the command-line:
 ```bash
 echo '(expression-here)' | npm start
 ```
 
-... and use the result in another command.
+... and use the result in another command:
 ```bash
 echo '(expression-here)' | npm start | cat
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # KnowSheet-REPL
-REPL interactive shell that demonstrates Bricks C++ syntax.
+A Read-Eval-Print-Loop (REPL) to demonstrate the KnowSheet Bricks C++ syntax.
 
 ## Installation
+
+[Node.js](http://nodejs.org/) v0.12.0 is required to install and run the REPL.
 
 ```bash
 git clone https://github.com/KnowSheet/KnowSheet-REPL.git
@@ -22,9 +24,19 @@ Perform an HTTP GET request and print the response:
 KnowSheet> HTTP(GET("http://httpbin.org/get?query=1")).body
 ```
 
+Parse a JSON response into an object, get a field from it:
+```
+KnowSheet> JSONParse(HTTP(GET("http://httpbin.org/get?query=1")).body).args
+```
+
 Perform an HTTP POST request and print the response:
 ```
 KnowSheet> HTTP(POST("http://httpbin.org/post", "BODY", "text/plain")).body
+```
+
+POST a JSON-encoded object (in C++, you'll have a cerealizable object in place of the `DemoObject()`):
+```
+KnowSheet> JSONParse(HTTP(POST("http://httpbin.org/post", DemoObject())).body).json
 ```
 
 Allow redirects:
@@ -37,9 +49,4 @@ Provide a custom User-Agent:
 KnowSheet> HTTP(GET("http://httpbin.org/get").UserAgent("KnowSheet-REPL/1.0.0")).body
 ```
 
-To quit REPL, hit `Ctrl+C` twice:
-```
-KnowSheet> 
-(^C again to quit)
-KnowSheet> 
-```
+

--- a/README.md
+++ b/README.md
@@ -62,8 +62,12 @@ Provide a custom User-Agent:
 KnowSheet> HTTP(GET("http://httpbin.org/get").UserAgent("KnowSheet-REPL/1.0.0")).body
 ```
 
+Provide extra HTTP headers:
+```
+KnowSheet> HTTP(GET("http://httpbin.org/get?query=1", HTTPHeaders().Set("Custom", "Header"))).body
+```
+
 Chain requests:
 ```
 KnowSheet> JSONParse(HTTP(POST("http://httpbin.org/post", JSONParse(HTTP(GET("http://httpbin.org/get?query=1")).body))).body)
 ```
-

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ KnowSheet> HTTP(GET("http://httpbin.org/get").UserAgent("KnowSheet-REPL/1.0.0"))
 Provide extra HTTP headers:
 ```
 KnowSheet> HTTP(GET("http://httpbin.org/get?query=1", HTTPHeaders().Set("Custom", "Header"))).body
+KnowSheet> HTTP(POST("http://httpbin.org/post", "BODY", "text/plain", HTTPHeaders().Set("Custom", "Header"))).body
 ```
 
 Chain requests:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The command prompt `KnowSheet> ` will appear.
 echo 'HTTP(GET("http://httpbin.org/get?query=1")).body' | npm start
 ```
 
-... and use the result in another command:
+... or evaluate and pass the result to another command:
 ```bash
 echo 'HTTP(GET("http://httpbin.org/get?query=1")).body' | npm start | cat
 ```

--- a/README.md
+++ b/README.md
@@ -19,14 +19,21 @@ npm start
 ```
 The command prompt `KnowSheet> ` will appear.
 
+... or evaluate one expression from the command-line.
+```bash
+echo '(expression-here)' | npm start
+```
+
+... and use the result in another command.
+```bash
+echo '(expression-here)' | npm start | cat
+```
+
+### Expressions
+
 Perform an HTTP GET request and print the response:
 ```
 KnowSheet> HTTP(GET("http://httpbin.org/get?query=1")).body
-```
-
-Parse a JSON response into an object, get a field from it:
-```
-KnowSheet> JSONParse(HTTP(GET("http://httpbin.org/get?query=1")).body).args
 ```
 
 Perform an HTTP POST request and print the response:
@@ -34,10 +41,16 @@ Perform an HTTP POST request and print the response:
 KnowSheet> HTTP(POST("http://httpbin.org/post", "BODY", "text/plain")).body
 ```
 
-POST a JSON-encoded object (in C++, you'll have a cerealizable object in place of the `DemoObject()`):
+Parse a JSON response into an object, get a field from it:
+```
+KnowSheet> JSONParse(HTTP(GET("http://httpbin.org/get?query=1")).body).args
+```
+
+POST a JSON-encoded object:
 ```
 KnowSheet> JSONParse(HTTP(POST("http://httpbin.org/post", DemoObject())).body).json
 ```
+<sub>(in C++, you'll have a cerealizable object in place of the `DemoObject()`)</sub>
 
 Allow redirects:
 ```
@@ -49,4 +62,8 @@ Provide a custom User-Agent:
 KnowSheet> HTTP(GET("http://httpbin.org/get").UserAgent("KnowSheet-REPL/1.0.0")).body
 ```
 
+Chain requests:
+```
+KnowSheet> JSONParse(HTTP(POST("http://httpbin.org/post", JSONParse(HTTP(GET("http://httpbin.org/get?query=1")).body))).body)
+```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ POST a JSON-encoded object:
 ```
 KnowSheet> JSONParse(HTTP(POST("http://httpbin.org/post", DemoObject())).body).json
 ```
-<sub>(in C++, you'll have a cerealizable object in place of the `DemoObject()`)</sub>
+<sup>(in C++, you'll have a cerealizable object in place of the `DemoObject()`)</sup>
 
 Allow redirects:
 ```

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ The command prompt `KnowSheet> ` will appear.
 
 ... or evaluate one expression from the command-line:
 ```bash
-echo '(expression-here)' | npm start
+echo 'HTTP(GET("http://httpbin.org/get?query=1")).body' | npm start
 ```
 
 ... and use the result in another command:
 ```bash
-echo '(expression-here)' | npm start | cat
+echo 'HTTP(GET("http://httpbin.org/get?query=1")).body' | npm start | cat
 ```
 
 ### Expressions

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ POST a JSON-encoded object:
 ```
 KnowSheet> JSONParse(HTTP(POST("http://httpbin.org/post", DemoObject())).body).json
 ```
-<sup>(in C++, you'll have a cerealizable object in place of the `DemoObject()`)</sup>
+<sup>The syntax mimics C++ Bricks exactly, as long as `DemoObject` is defined as a serializable type.</sup>
 
 Allow redirects:
 ```

--- a/README.md
+++ b/README.md
@@ -15,19 +15,25 @@ npm install
 
 Start the REPL from the terminal:
 ```bash
-npm start
+node run
 ```
 The command prompt `KnowSheet> ` will appear.
 
 ... or evaluate one expression from the command-line:
 ```bash
-echo 'HTTP(GET("http://httpbin.org/get?query=1")).body' | npm start
+echo 'HTTP(GET("http://httpbin.org/get?query=1")).body' | node run
 ```
 
 ... or evaluate and pass the result to another command:
 ```bash
-echo 'HTTP(GET("http://httpbin.org/get?query=1")).body' | npm start | cat
+echo 'HTTP(GET("http://httpbin.org/get?query=1")).body' | node run | cat
 ```
+
+Override the default prompt:
+```bash
+node run --prompt 'Bricks> '
+```
+The command prompt `Bricks> ` will appear.
 
 ### Expressions
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # KnowSheet-REPL
-A Read-Eval-Print-Loop (REPL) to demonstrate the KnowSheet Bricks C++ syntax.
+A Read-Eval-Print-Loop (REPL) shell to demonstrate the KnowSheet Bricks C++ syntax.
 
 ## Installation
 

--- a/lib/bricks-evaluate.js
+++ b/lib/bricks-evaluate.js
@@ -52,10 +52,10 @@ function createContext() {
 	// Add a `DemoObject` to demonstrate the JSON-POST.
 	context.DemoObject = function () {
 		return {
-			"string": "string",
-			"number": 123.456,
-			"array": [ 1, 2, 3 ],
-			"object": {
+			"demo_string": "string",
+			"demo_number": 123.456,
+			"demo_array": [ 1, 2, 3 ],
+			"dmeo_object": {
 				"key": "value"
 			}
 		};

--- a/lib/bricks-evaluate.js
+++ b/lib/bricks-evaluate.js
@@ -49,6 +49,24 @@ function createContext() {
 	extend(context, require('./bricks-net-api'));
 	
 	
+	// Add a `DemoObject` to demonstrate the JSON-POST.
+	context.DemoObject = function () {
+		return {
+			"string": "string",
+			"number": 123.456,
+			"array": [ 1, 2, 3 ],
+			"object": {
+				"key": "value"
+			}
+		};
+	};
+	context.DemoObject.inspect = context.DemoObject.toString = function () {
+		return new (require('./bricks-prettyprint').Documentation)(
+			'// A cerealizable class for JSON-POST demonstration.'
+		);
+	};
+	
+	
 	// Freeze the context.
 	for (var x in context) {
 		Object.defineProperty(context, x, {

--- a/lib/bricks-evaluate.js
+++ b/lib/bricks-evaluate.js
@@ -15,13 +15,25 @@ var extend = require('./extend');
 function createContext() {
 	var context = vm.createContext();
 	
+	var api = require('./bricks-net-api');
+	
+	
+	function hideContextProperty(x) {
+		Object.defineProperty(context, x, {
+			configurable: false,
+			enumerable: (x in api ? true : false),
+			writable: false,
+			value: (x in api ? api[x] : undefined)
+		});
+	}
+	
 	
 	// Blacklist everything that does not make sense in C++ code.
 	// TODO(sompylasar): Add checks for these objects to the source code transform.
 	
 	// - everything in `global`.
 	for (var x in global) {
-		context[x] = undefined;
+		hideContextProperty(x);
 	}
 	
 	// - the standard object types that are not in `global`.
@@ -31,7 +43,7 @@ function createContext() {
 		Int8Array, Uint16Array, Uint32Array, Uint8Array,
 		Error, EvalError, RangeError, ReferenceError, SyntaxError, TypeError, URIError
 	].forEach(function (x) {
-		context[x.name] = undefined;
+		hideContextProperty(x.name);
 	});
 	
 	// - the Node.js-specific items.
@@ -41,12 +53,12 @@ function createContext() {
 		'global',
 		'JSON'
 	].forEach(function (x) {
-		context[x] = undefined;
+		hideContextProperty(x);
 	});
 	
 	
 	// Add Bricks API.
-	extend(context, require('./bricks-net-api'));
+	extend(context, api);
 	
 	
 	/**
@@ -91,11 +103,13 @@ function createContext() {
 	
 	// Freeze the context.
 	for (var x in context) {
-		Object.defineProperty(context, x, {
-			configurable: false,
-			enumerable: true,
-			writable: false
-		});
+		if (context[x] !== undefined) {
+			Object.defineProperty(context, x, {
+				configurable: false,
+				enumerable: true,
+				writable: false
+			});
+		}
 	}
 	
 	
@@ -385,6 +399,46 @@ function evaluateDefault(code, callback, options) {
 }
 
 
+function complete(line, callback, options) {
+	if (/(([^a-zA-Z_]|^)\s*)(GET|POST)\(["']$/.test(line)) {
+		callback(null, [ [ 'http://' ], '' ]);
+		return;
+	}
+	
+	if (/["']$/.test(line)) {
+		callback(null, [ [], line ]);
+		return;
+	}
+	
+	var context = (options && options.context) || createContext();
+	
+	var RE_TRAILING_IDENTIFIER = /(([^a-zA-Z_]|^)\s*)([a-zA-Z_][a-zA-Z0-9_]*)\s*$/;
+	
+	var trailingIdentifierMatch = RE_TRAILING_IDENTIFIER.exec(line);
+	var trailingIdentifierName = (trailingIdentifierMatch && trailingIdentifierMatch[2] !== '.'
+		? trailingIdentifierMatch[3]
+		: undefined
+	);
+	
+	var keys = Object.keys(context);
+	
+	var completions = (
+		trailingIdentifierName
+			? keys.filter(function (k) {
+				return (context[k] !== undefined && k.indexOf(trailingIdentifierName) === 0);
+			})
+			: keys
+	);
+	
+	if (trailingIdentifierName && typeof context[trailingIdentifierName] === 'function') {
+		completions = [ trailingIdentifierName + '()' ];
+	}
+	
+	callback(null, [ completions, (trailingIdentifierName ? trailingIdentifierName : line) ]);
+}
+
+
 module.exports = evaluateDefault;
 module.exports.createContext = createContext;
 module.exports.evaluate = evaluate;
+module.exports.complete = complete;

--- a/lib/bricks-evaluate.js
+++ b/lib/bricks-evaluate.js
@@ -49,22 +49,44 @@ function createContext() {
 	extend(context, require('./bricks-net-api'));
 	
 	
-	// Add a `DemoObject` to demonstrate the JSON-POST.
-	context.DemoObject = function () {
-		return {
-			"demo_string": "string",
-			"demo_number": 123.456,
-			"demo_array": [ 1, 2, 3 ],
-			"dmeo_object": {
-				"key": "value"
-			}
+	/**
+	 * A class that mimics the C++ serializable type to demonstrate the JSON-POST.
+	 */
+	function DemoObject() {
+		if (!(this instanceof DemoObject)) {
+			return new DemoObject();
+		}
+		
+		this.demo_string = "string";
+		this.demo_double = 123.456;
+		this.demo_vector = [ 1, 2, 3 ];
+		this.demo_map = {
+			"key": "value"
 		};
-	};
-	context.DemoObject.inspect = context.DemoObject.toString = function () {
+	}
+	
+	/**
+	 * Custom inspect function for the `DemoObject`.
+	 * Returns an instance of the `Documentation` object 
+	 * that will be handled in a special way by the pretty-printer.
+	 *
+	 * For example, if you evaluate just `DemoObject`:
+	 * `KnowSheet> DemoObject`
+	 * the interactive shell will print:
+	 * `// A cerealizable class for JSON-POST demonstration.`
+	 *
+	 * @see bricks-prettyprint
+	 *
+	 * @return {Documentation} The documentation object.
+	 */
+	DemoObject.inspect = DemoObject.toString = function () {
 		return new (require('./bricks-prettyprint').Documentation)(
 			'// A cerealizable class for JSON-POST demonstration.'
 		);
 	};
+	
+	// Add the `DemoObject` to the context.
+	context.DemoObject = DemoObject;
 	
 	
 	// Freeze the context.

--- a/lib/bricks-evaluate.js
+++ b/lib/bricks-evaluate.js
@@ -96,25 +96,115 @@ function transformCode(code, options) {
 	var n = recast.types.namedTypes;
 	var b = recast.types.builders;
 	
+	var retIdentifierName = '__ret' + Math.floor(1000 + Math.random() * 1000);
+	
+	var whenIdentifier = b.identifier(options.when);
+	var thenIdentifier = b.identifier('then');
+	var joinIdentifier = b.identifier('join');
+	var retIdentifier = b.identifier(retIdentifierName);
+	
+	
+	/**
+	 * Throws a `SyntaxError` for blacklisted expressions.
+	 */
+	function throwSyntaxError(node) {
+		throw new SyntaxError('Invalid expression: ' + recast.print(node).code);
+	}
+	
+	/**
+	 * Blacklist several JavaScript expressions that require additional check logic.
+	 */
+	function checkBlacklist(node) {
+		// Blacklist `this` references (e.g. `this.something`).
+		if (n.MemberExpression.check(node) && n.ThisExpression.check(node.object)) {
+			throwSyntaxError(node);
+		}
+		
+		// Blacklist computed MemberExpression (e.g. `obj["property"]`).
+		if (n.MemberExpression.check(node) && node.computed) {
+			throwSyntaxError(node);
+		}
+		
+		// Check the expression that is being called as a function.
+		if (n.CallExpression.check(node)) {
+			checkBlacklist(node.callee);
+		}
+	}
+	
+	/**
+	 * Performs the following AST transform for a CallExpression:
+	 *     aaa(bbb, ccc) -> when.join(bbb, ccc).then(function (ret) { return aaa(ret[0], ret[1]); })
+	 */
+	function whenThenCallExpression(callExpression) {
+		checkBlacklist(callExpression);
+		
+		// No need to wrap the empty list.
+		if (callExpression.arguments.length === 0) {
+			return callExpression;
+		}
+		
+		// No need to wrap if all the arguments are literals.
+		var allLiterals = true;
+		for (var ic = callExpression.arguments.length, i = 0; i < ic; ++i) {
+			allLiterals = allLiterals && n.Literal.check(callExpression.arguments[i]);
+		}
+		if (allLiterals) {
+			return callExpression;
+		}
+		
+		var joinMember = b.memberExpression(
+			whenIdentifier,
+			joinIdentifier,
+			false
+		);
+		
+		var callWhen = b.callExpression(joinMember, callExpression.arguments.map(whenThen));
+		
+		var thenMember = b.memberExpression(
+			callWhen,
+			thenIdentifier,
+			false
+		);
+		
+		var retArguments = callExpression.arguments.map(function (arg, index) {
+			return b.memberExpression(
+				retIdentifier,
+				b.literal(index),
+				true
+			);
+		});
+		
+		var functionExpression = b.functionExpression(
+			null,
+			[ retIdentifier ],
+			b.blockStatement(
+				[
+					b.returnStatement(
+						b.callExpression(
+							callExpression.callee,
+							retArguments
+						)
+					)
+				]
+			)
+		);
+		
+		var callThen = b.callExpression(thenMember, [
+			functionExpression
+		]);
+		
+		return callThen;
+	}
+	
 	/**
 	 * Performs the following AST transform for a MemberExpression:
 	 *     aaa.bbb -> when(aaa).then(function (ret) { return ret.bbb; })
 	 */
-	function wrapWithWhenThen(memberExpression) {
-		if (!n.MemberExpression.check(memberExpression)) {
-			return memberExpression;
-		}
-		
-		// Blacklist `this` references.
-		if (n.ThisExpression.check(memberExpression.object)) {
-			throwSyntaxError(memberExpression);
-		}
-		
-		var whenIdentifier = b.identifier(options.when);
-		var thenIdentifier = b.identifier('then');
+	function whenThenMemberExpression(memberExpression) {
+		checkBlacklist(memberExpression);
 		
 		var callWhen = b.callExpression(whenIdentifier, [
-			wrapWithWhenThen(memberExpression.object)
+			whenThen(memberExpression.object)
 		]);
 		
 		var thenMember = b.memberExpression(
@@ -123,7 +213,6 @@ function transformCode(code, options) {
 			false
 		);
 		
-		var retIdentifier = b.identifier("ret");
 		var functionExpression = b.functionExpression(
 			null,
 			[ retIdentifier ],
@@ -147,18 +236,32 @@ function transformCode(code, options) {
 		return callThen;
 	}
 	
-	function throwSyntaxError(node) {
-		throw new SyntaxError('Invalid expression: ' + recast.print(node).code);
+	/**
+	 * Wraps the given AST node in a `when(...).then(...)`.
+	 */
+	function whenThen(node) {
+		checkBlacklist(node);
+		
+		if (n.MemberExpression.check(node)) {
+			return whenThenMemberExpression(node);
+		}
+		else if (n.CallExpression.check(node)) {
+			return whenThenCallExpression(node);
+		}
+		else {
+			return node;
+		}
 	}
 	
+	
+	// The AST visitors.
 	var visitors = {
-		visitMemberExpression: function (node) {
-			// Blacklist computed MemberExpression (e.g. obj["property"]).
-			if (node.value.computed) {
-				throwSyntaxError(node.value);
-			}
-			
-			node.replace(wrapWithWhenThen(node.value));
+		visitCallExpression: function (path) {
+			path.replace(whenThen(path.value));
+			return false;
+		},
+		visitMemberExpression: function (path) {
+			path.replace(whenThen(path.value));
 			return false;
 		},
 		
@@ -177,6 +280,8 @@ function transformCode(code, options) {
 		visitDebuggerStatement: throwSyntaxError
 	};
 	
+	
+	// Parse and transform the AST, then compile back into the source code.
 	var ast = recast.parse(code);
 	recast.visit(ast, visitors);
 	return recast.print(ast).code;

--- a/lib/bricks-net-api-types.js
+++ b/lib/bricks-net-api-types.js
@@ -36,20 +36,69 @@ function notImplementedMethod() {
 }
 
 
+function DefaultContentType() { return "text/plain"; }
+
+
+function HTTPHeaders() {
+	if (!(this instanceof HTTPHeaders)) {
+		return new HTTPHeaders();
+	}
+	
+	Object.defineProperties(this, {
+		headers: {
+			configurable: false,
+			enumerable: true,
+			writable: false,
+			value: []
+		}
+	});
+}
+HTTPHeaders.prototype.Set = function () {
+	var _this = this;
+	
+	cppArguments.assert('HTTPHeaders#Set', [
+		[
+			cppArguments.assertion('string', 'const std::string&', 'key'),
+			cppArguments.assertion('string', 'const std::string&', 'value'),
+			function (key, value) {
+				_this.headers.push({
+					first: key,
+					second: value
+				});
+			}
+		]
+	], arguments);
+	
+	return _this;
+};
+
+
 // Structures to define HTTP requests.
 // Support GET and POST.
 // The syntax for creating an instance of a GET request is GET is `GET(url)`.
 // The syntax for creating an instance of a POST request is POST is `POST(url, data, content_type)`'.
 // Alternatively, `POSTFromFile(url, file_name, content_type)` is supported.
 // Both GET and two forms of POST allow `.UserAgent(custom_user_agent)`.
-function HTTPRequestBase(url) {
-	cppArguments.assert('HTTPRequestBase', [
-		[ cppArguments.assertion('string', 'const std::string&', 'url') ]
-	], arguments);
+function HTTPRequestBase() {
+	var _this = this;
 	
-	this.url = url;
-	this.custom_user_agent = "";
-	this.allow_redirects = false;
+	_this.url = "";
+	_this.custom_user_agent = "";
+	_this.allow_redirects = false;
+	_this.extra_headers = HTTPHeaders().headers;
+	
+	cppArguments.assert('HTTPRequestBase', [
+		[
+			cppArguments.assertion('string', 'const std::string&', 'url'),
+			cppArguments.assertion(function (value) {
+				return (value instanceof HTTPHeaders);
+			}, 'const HTTPHeaders&', 'extra_headers'),
+			function (url, extra_headers) {
+				_this.url = url;
+				_this.extra_headers = extra_headers.headers;
+			}
+		]
+	], arguments);
 }
 HTTPRequestBase.prototype.UserAgent = function (new_custom_user_agent) {
 	cppArguments.assert('HTTPRequestBase::UserAgent', [
@@ -75,19 +124,46 @@ HTTPRequestBase.prototype.AllowRedirects = function (allow_redirects_setting) {
 };
 
 
-function GET(url) {
+function GET() {
 	var _this = this;
 	
 	if (!(_this instanceof GET)) {
-		_this = new GET(url);
+		// TODO(sompylasar): Abstract this away.
+		// HACK: Cannot use `apply` to call a constructor with the exact number of arguments.
+		switch (arguments.length) {
+			case 0:
+				// HACK: We know `GET` `cppArguments.assert` will throw on this.
+				_this = new GET();
+				/* istanbul ignore next: previous statement should throw */ break;
+			
+			case 1:
+				_this = new GET(arguments[0]);
+				break;
+			
+			case 2:
+				_this = new GET(arguments[0], arguments[1]);
+				break;
+			
+			default:
+				// HACK: We know `GET` `cppArguments.assert` will throw on this.
+				_this = new GET(arguments[0], arguments[1], arguments[2]);
+				/* istanbul ignore next: previous statement should throw */ break;
+		}
 		return _this;
 	}
 	
 	cppArguments.assert('GET', [
 		[
 			cppArguments.assertion('string', 'const std::string&', 'url'),
-			function (url) {
-				HTTPRequestBase.call(_this, url);
+			cppArguments.assertion(function (value) {
+				return (value instanceof HTTPHeaders);
+			}, 'const HTTPHeaders&', 'extra_headers', cppArguments.ASSERTION_MODE_OPTIONAL),
+			function (url, extra_headers) {
+				if (typeof extra_headers === 'undefined') {
+					extra_headers = HTTPHeaders();
+				}
+				
+				HTTPRequestBase.call(_this, url, extra_headers);
 			}
 		]
 	], arguments);
@@ -95,32 +171,37 @@ function GET(url) {
 inherits(GET, HTTPRequestBase);
 
 
-function POST(url) {
+function POST() {
 	var _this = this;
 	
 	if (!(_this instanceof POST)) {
+		// TODO(sompylasar): Abstract this away.
 		// HACK: Cannot use `apply` to call a constructor with the exact number of arguments.
 		switch (arguments.length) {
 			case 0:
 				// HACK: We know `POST` `cppArguments.assert` will throw on this.
 				_this = new POST();
 				/* istanbul ignore next: previous statement should throw */ break;
-		
+			
 			case 1:
 				_this = new POST(arguments[0]);
 				break;
-		
+			
 			case 2:
 				_this = new POST(arguments[0], arguments[1]);
 				break;
-		
+			
 			case 3:
 				_this = new POST(arguments[0], arguments[1], arguments[2]);
 				break;
-		
+			
+			case 4:
+				_this = new POST(arguments[0], arguments[1], arguments[2], arguments[3]);
+				break;
+			
 			default:
 				// HACK: We know `POST` `cppArguments.assert` will throw on this.
-				_this = new POST(arguments[0], arguments[1], arguments[2], arguments[3]);
+				_this = new POST(arguments[0], arguments[1], arguments[2], arguments[3], arguments[4]);
 				/* istanbul ignore next: previous statement should throw */ break;
 		}
 		return _this;
@@ -128,21 +209,32 @@ function POST(url) {
 	
 	_this.has_body = false;
 	_this.body = "";
-	_this.content_type = "";
+	_this.content_type = DefaultContentType();
 	
 	cppArguments.assert('POST', [
 		[
 			cppArguments.assertion('string', 'const std::string&', 'url'),
 			function (url) {
-				HTTPRequestBase.call(_this, url);
+				HTTPRequestBase.call(_this, url, HTTPHeaders());
 			}
 		],
 		[
 			cppArguments.assertion('string', 'const std::string&', 'url'),
 			cppArguments.assertion('string', 'const std::string&', 'body'),
-			cppArguments.assertion('string', 'const std::string&', 'content_type'),
-			function (url, body, content_type) {
-				HTTPRequestBase.call(_this, url);
+			cppArguments.assertion('string', 'const std::string&', 'content_type', cppArguments.ASSERTION_MODE_OPTIONAL),
+			cppArguments.assertion(function (value) {
+				return (value instanceof HTTPHeaders);
+			}, 'const HTTPHeaders&', 'extra_headers', cppArguments.ASSERTION_MODE_OPTIONAL),
+			function (url, body, content_type, extra_headers) {
+				if (typeof content_type === 'undefined') {
+					content_type = DefaultContentType();
+				}
+				
+				if (typeof extra_headers === 'undefined') {
+					extra_headers = HTTPHeaders();
+				}
+				
+				HTTPRequestBase.call(_this, url, extra_headers);
 				
 				_this.has_body = true;
 				_this.body = body;
@@ -152,12 +244,24 @@ function POST(url) {
 		[
 			cppArguments.assertion('string', 'const std::string&', 'url'),
 			cppArguments.assertion('object', 'const T&', 'object'),
-			function (url, object) {
-				HTTPRequestBase.call(_this, url);
+			cppArguments.assertion('string', 'const std::string&', 'content_type', cppArguments.ASSERTION_MODE_OPTIONAL),
+			cppArguments.assertion(function (value) {
+				return (value instanceof HTTPHeaders);
+			}, 'const HTTPHeaders&', 'extra_headers', cppArguments.ASSERTION_MODE_OPTIONAL),
+			function (url, object, content_type, extra_headers) {
+				if (typeof content_type === 'undefined') {
+					content_type = "application/json";
+				}
+				
+				if (typeof extra_headers === 'undefined') {
+					extra_headers = HTTPHeaders();
+				}
+				
+				HTTPRequestBase.call(_this, url, extra_headers);
 				
 				_this.has_body = true;
 				_this.body = JSON.stringify({ data: object });
-				_this.content_type = "application/json";
+				_this.content_type = content_type;
 			}
 		]
 	], arguments);
@@ -180,9 +284,20 @@ function POSTFromFile(url, file_name, content_type) {
 		[
 			cppArguments.assertion('string', 'const std::string&', 'url'),
 			cppArguments.assertion('string', 'const std::string&', 'file_name'),
-			cppArguments.assertion('string', 'const std::string&', 'content_type'),
-			function (url, file_name, content_type) {
-				HTTPRequestBase.call(_this, url);
+			cppArguments.assertion('string', 'const std::string&', 'content_type', cppArguments.ASSERTION_MODE_OPTIONAL),
+			cppArguments.assertion(function (value) {
+				return (value instanceof HTTPHeaders);
+			}, 'const HTTPHeaders&', 'extra_headers', cppArguments.ASSERTION_MODE_OPTIONAL),
+			function (url, file_name, content_type, extra_headers) {
+				if (typeof content_type === 'undefined') {
+					content_type = DefaultContentType();
+				}
+				
+				if (typeof extra_headers === 'undefined') {
+					extra_headers = HTTPHeaders();
+				}
+				
+				HTTPRequestBase.call(_this, url, extra_headers);
 	
 				_this.file_name = file_name;
 				_this.content_type = content_type;
@@ -869,7 +984,8 @@ function HTTPClient() {
 	_this.request_has_body_ = false;
 	_this.request_body_contents_ = "";
 	_this.request_user_agent_ = "";
-
+	_this.request_extra_headers_ = [];
+	
 	// Output parameters.
 	_this.response_code_ = HTTPResponseCode.InvalidCode;
 	_this.response_url_after_redirects_ = "";
@@ -909,11 +1025,15 @@ function HTTPClient() {
 	
 		if (_this.request_has_body_) {
 			writes.push("Content-Length: " + _this.request_body_contents_.length + "\r\n");
-			writes.push("\r\n");
-			writes.push(_this.request_body_contents_);
 		}
-		else {
-			writes.push("\r\n");
+		
+		_this.request_extra_headers_.forEach(function (header) {
+			writes.push(header.first + ": " + header.second + "\r\n");
+		});
+		writes.push("\r\n");
+		
+		if (_this.request_has_body_) {
+			writes.push(_this.request_body_contents_);
 		}
 		
 		var sequence = [];
@@ -1045,6 +1165,7 @@ function PrepareInput(request, client) {
 		if (request.custom_user_agent) {
 			client.request_user_agent_ = request.custom_user_agent;
 		}
+		client.request_extra_headers_ = request.extra_headers;
 	}
 	else if (request instanceof POST) {
 		client.request_method_ = "POST";
@@ -1052,6 +1173,7 @@ function PrepareInput(request, client) {
 		if (request.custom_user_agent) {
 			client.request_user_agent_ = request.custom_user_agent;
 		}
+		client.request_extra_headers_ = request.extra_headers;
 		client.request_has_body_ = request.has_body;
 		if (request.has_body) {
 			client.request_body_contents_ = request.body;
@@ -1064,6 +1186,7 @@ function PrepareInput(request, client) {
 		if (request.custom_user_agent) {
 			client.request_user_agent_ = request.custom_user_agent;
 		}
+		client.request_extra_headers_ = request.extra_headers;
 		client.request_has_body_ = true;
 		client.request_body_contents_ = fs.readFileSync(request.file_name);  // Can throw.
 		client.request_body_content_type_ = request.content_type;
@@ -1165,12 +1288,17 @@ function HTTP() {
 
 exports.URL = URL;
 
-exports.GET = GET;
-exports.POST = POST;
-exports.POSTFromFile = POSTFromFile;
-exports.HTTP = HTTP;
+exports.DefaultContentType = DefaultContentType;
+
+exports.HTTPHeaders = HTTPHeaders;
 
 exports.HTTPResponse = HTTPResponse;
 
+exports.GET = GET;
+exports.POST = POST;
+exports.POSTFromFile = POSTFromFile;
+
 exports.KeepResponseInMemory = KeepResponseInMemory;
 exports.SaveResponseToFile = SaveResponseToFile;
+
+exports.HTTP = HTTP;

--- a/lib/bricks-net-api.js
+++ b/lib/bricks-net-api.js
@@ -2,7 +2,11 @@
 
 var when = require('when');
 
-exports.URL = require('./bricks-net-url').URL;
+exports.URL = require('./bricks-net-api-types').URL;
+
+exports.DefaultContentType = require('./bricks-net-api-types').DefaultContentType;
+
+exports.HTTPHeaders = require('./bricks-net-api-types').HTTPHeaders;
 
 exports.HTTPResponse = require('./bricks-net-api-types').HTTPResponse;
 
@@ -12,10 +16,11 @@ exports.HTTPResponseCodeAsString = require('./bricks-net-http-codes').HTTPRespon
 exports.GET = require('./bricks-net-api-types').GET;
 exports.POST = require('./bricks-net-api-types').POST;
 exports.POSTFromFile = require('./bricks-net-api-types').POSTFromFile;
-exports.HTTP = require('./bricks-net-api-types').HTTP;
 
 exports.KeepResponseInMemory = require('./bricks-net-api-types').KeepResponseInMemory;
 exports.SaveResponseToFile = require('./bricks-net-api-types').SaveResponseToFile;
+
+exports.HTTP = require('./bricks-net-api-types').HTTP;
 
 exports.JSON = function (arg) {
 	return when(arg).then(function (ret) {

--- a/lib/bricks-net-api.js
+++ b/lib/bricks-net-api.js
@@ -35,18 +35,30 @@ exports.JSONParse = function (arg) {
 };
 
 /**
- * Custom inspect function for the API items.
- * Returns an instance of the `Documentation` object 
- * that will be handled in a special way by the pretty-printer.
+ * Creates a custom inspect function for the API items.
  *
  * @param {string} name The object export name.
  * @param {Object} instance The object being documented.
- * @return {Documentation} The documentation object.
+ * @return {Function} The custom inspect function that returns an instance of the `Documentation` object.
  */
 function makeInspectDocumentationMethod(name, instance) {
+	/**
+	 * Custom inspect function for an API item.
+	 * Returns an instance of the `Documentation` object 
+	 * that will be handled in a special way by the pretty-printer.
+	 *
+	 * For example, if you evaluate just `HTTP`:
+	 * `KnowSheet> HTTP`
+	 * the interactive shell will print:
+	 * `// KnowSheet Bricks HTTP.`
+	 *
+	 * @see bricks-prettyprint
+	 *
+	 * @return {Documentation} The documentation object.
+	 */
 	return function () {
 		// TODO(sompylasar): Replace with the actual usage documentation.
-		return new (require('./bricks-prettyprint').Documentation)('// KnowSheet ' + name + '');
+		return new (require('./bricks-prettyprint').Documentation)('// KnowSheet Bricks ' + name + '');
 	};
 }
 

--- a/lib/bricks-net-url.js
+++ b/lib/bricks-net-url.js
@@ -47,6 +47,19 @@ function URL() {
 	var kDefaultScheme = "http";
 	
 	
+	// Defaults from `URLWithoutParametersParser`.
+	_this.host = "";
+	_this.path = "/";
+	_this.scheme = kDefaultScheme;
+	_this.port = 0;
+	
+	// Defaults from `URLParametersExtractor`.
+	_this.parameters_vector = [];
+	_this.query = new QueryParameters(_this.parameters_vector);
+	_this.fragment = "";
+	_this.url_without_parameters = "";
+	
+	
 	function DefaultPortForScheme(scheme) {
 		// We don't really "support" other schemes yet -- D.K.
 		if (scheme == "http") {
@@ -75,11 +88,6 @@ function URL() {
 	
 	function URLWithoutParametersParser() {
 		// NOTE: Using `this` from the outer scope (the `URL`).
-		
-		_this.host = "";
-		_this.path = "/";
-		_this.scheme = kDefaultScheme;
-		_this.port = 0;
 		
 		cppArguments.assert('URLWithoutParametersParser', [
 			[
@@ -189,11 +197,6 @@ function URL() {
 	function URLParametersExtractor(url) {
 		// NOTE: Using `this` from the outer scope (the `URL`).
 		
-		_this.parameters_vector = [];
-		_this.query = new QueryParameters(_this.parameters_vector);
-		_this.fragment = "";
-		_this.url_without_parameters = "";
-		
 		var pound_sign_index = url.indexOf('#');
 		if (pound_sign_index >= 0) {
 			_this.fragment = url.substr(pound_sign_index + 1);
@@ -224,51 +227,6 @@ function URL() {
 			url = url.substr(0, question_mark_index);
 		}
 		_this.url_without_parameters = url;
-		
-		function QueryParameters(parameters_vector) {
-			var _this = this;
-			
-			_this.parameters_ = {};
-			
-			parameters_vector.forEach(function (param) {
-				_this.parameters_[param.first] = param.second;
-			});
-		}
-		QueryParameters.prototype.has = function (key) {
-			var _this = this;
-			var retval = false;
-			
-			cppArguments.assert('QueryParameters', [
-				[
-					cppArguments.assertion('string', 'const std::string&', 'key'),
-					function (key) {
-						retval = (typeof _this.parameters_[key] === 'string');
-					}
-				]
-			], arguments);
-			
-			return retval;
-		};
-		QueryParameters.prototype.get = function () {
-			var _this = this;
-			var retval = '';
-			
-			cppArguments.assert('QueryParameters', [
-				[
-					cppArguments.assertion('string', 'const std::string&', 'key'),
-					cppArguments.assertion('string', 'const std::string&', 'default_value', cppArguments.ASSERTION_MODE_OPTIONAL),
-					function (key, default_value) {
-						if (typeof default_value === 'undefined') {
-							default_value = '';
-						}
-						
-						retval = (_this.has(key) ? _this.parameters_[key] : default_value);
-					}
-				]
-			], arguments);
-			
-			return retval;
-		};
 	}
 	function URLParametersExtractor_ComposeParameters() {
 		var composed_parameters = "";
@@ -284,8 +242,56 @@ function URL() {
 	}
 	
 	
+	function QueryParameters(parameters_vector) {
+		var _this = this;
+		
+		_this.parameters_ = {};
+		
+		parameters_vector.forEach(function (param) {
+			_this.parameters_[param.first] = param.second;
+		});
+	}
+	QueryParameters.prototype.has = function (key) {
+		var _this = this;
+		var retval = false;
+		
+		cppArguments.assert('QueryParameters', [
+			[
+				cppArguments.assertion('string', 'const std::string&', 'key'),
+				function (key) {
+					retval = (typeof _this.parameters_[key] === 'string');
+				}
+			]
+		], arguments);
+		
+		return retval;
+	};
+	QueryParameters.prototype.get = function () {
+		var _this = this;
+		var retval = '';
+		
+		cppArguments.assert('QueryParameters', [
+			[
+				cppArguments.assertion('string', 'const std::string&', 'key'),
+				cppArguments.assertion('string', 'const std::string&', 'default_value', cppArguments.ASSERTION_MODE_OPTIONAL),
+				function (key, default_value) {
+					if (typeof default_value === 'undefined') {
+						default_value = '';
+					}
+					
+					retval = (_this.has(key) ? _this.parameters_[key] : default_value);
+				}
+			]
+		], arguments);
+		
+		return retval;
+	};
+	
+	
 	cppArguments.assert('URL', [
-		[],
+		[
+			// Empty arguments. Defaults are used.
+		],
 		[
 			cppArguments.assertion('string', 'const std::string&', 'url'),
 			cppArguments.assertion('string', 'const std::string&', 'previous_scheme', cppArguments.ASSERTION_MODE_OPTIONAL),
@@ -323,6 +329,7 @@ function URL() {
 			}
 		]
 	], arguments);
+	
 	
 	this.ComposeParameters = function () {
 		return URLParametersExtractor_ComposeParameters();

--- a/lib/bricks-prettyprint.js
+++ b/lib/bricks-prettyprint.js
@@ -35,7 +35,7 @@ function prettyprintObject(obj, options) {
 			output = obj;
 		}
 		else {
-			output = util.inspect(obj, undefined, undefined, !!options.useColors);
+			output = util.inspect(obj, false, 20, !!options.useColors);
 		}
 	}
 	

--- a/lib/cpp-arguments.js
+++ b/lib/cpp-arguments.js
@@ -39,12 +39,17 @@ function assertArguments(methodName, signatures, values) {
 		return -(left.length - right.length);
 	});
 	
+	var signature = null;
+	var callback = null;
 	var error = null;
+	var matchedSignature = false;
+	var value;
+	var assertion;
+	var ic, i, jc, j;
 	
-	for (var ic = signatures.length, i = 0; i < ic; ++i) {
-		var signature = signatures[i];
-		
-		var callback;
+	for (ic = signatures.length, i = 0; i < ic; ++i) {
+		signature = signatures[i];
+		callback = null;
 		
 		if (signature.length > 0  && typeof signature[signature.length - 1] === 'function') {
 			callback = signature[signature.length - 1];
@@ -52,21 +57,21 @@ function assertArguments(methodName, signatures, values) {
 			signature.pop();
 		}
 		
-		var matchedSignature = (
+		matchedSignature = (
 			values.length <= signature.length
 			|| (signature.length > 0 
 				&& signature[signature.length - 1].mode === ASSERTION_MODE_VARARGS)
 		);
 		
 		if (matchedSignature) {
-			for (var jc = signature.length, j = 0; j < jc; ++j) {
-				var assertion = signature[j];
+			for (jc = signature.length, j = 0; j < jc; ++j) {
+				assertion = signature[j];
 				
 				if (assertion.mode === ASSERTION_MODE_OPTIONAL && j >= values.length) {
 					break;
 				}
 				
-				var value = values[j];
+				value = values[j];
 				
 				if (!assertion.check(value)) {
 					matchedSignature = false;

--- a/lib/cpp-arguments.js
+++ b/lib/cpp-arguments.js
@@ -4,8 +4,8 @@ var util = require('util');
 
 var extend = require('./extend');
 
-var ASSERTION_MODE_OPTIONAL = {};
-var ASSERTION_MODE_VARARGS = {};
+var ASSERTION_MODE_OPTIONAL = { ASSERTION_MODE_OPTIONAL: 1 };
+var ASSERTION_MODE_VARARGS = { ASSERTION_MODE_VARARGS: 1 };
 
 
 var Object_getPrototypeOf = Object.getPrototypeOf;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -89,6 +89,12 @@ KnowSheetREPLServer.prototype.createContext = function () {
 	return context;
 };
 
+KnowSheetREPLServer.prototype.complete = function (line, callback) {
+	require('./bricks-evaluate').complete(line, callback, {
+		context: this.context
+	});
+};
+
 
 module.exports = {
 	start: function (options) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^1.0.0",
+    "commander": "^2.6.0",
     "recast": "^0.10.4",
     "when": "^3.7.2"
   },

--- a/run.js
+++ b/run.js
@@ -1,7 +1,17 @@
 'use strict';
 
+var program = require('commander');
+var packageJson = require('./package.json');
+
+program
+	.version(packageJson.version)
+	.option('-p, --prompt <prompt>', 'override the default prompt')
+	.parse(process.argv);
+
 if (process.stdin.isTTY) {
-	module.exports = require('./lib/repl').start();
+	module.exports = require('./lib/repl').start({
+		prompt: program.prompt
+	});
 	return;
 }
 

--- a/test/bricks-net-api.test.js
+++ b/test/bricks-net-api.test.js
@@ -178,7 +178,7 @@ describe('bricks-net-api', function () {
 		
 		it('should set `body` and `has_body` (JSON)', function () {
 			var object = { test: [ 1, 2, 3 ] };
-			var body = JSON.stringify({ data: object });
+			var body = '{"data":{"test":[1,2,3]}}';
 			assert.strictEqual(body, api.POST("url", object).body);
 			assert.strictEqual(true, api.POST("url", object).has_body);
 		});
@@ -594,7 +594,7 @@ describe('bricks-net-api', function () {
 				"array": [],
 				"number": 123.456
 			};
-			var requestJson = JSON.stringify({ "data": requestObject });
+			var requestJson = '{"data":{"object":{},"array":[],"number":123.456}}';
 			
 			serverRequestHandler = function (request, response) {
 				try {
@@ -776,7 +776,7 @@ describe('bricks-net-api', function () {
 			when(
 				api.JSON(object)
 			).then(function (result) {
-				assert.strictEqual(JSON.stringify(object), result);
+				assert.strictEqual('{"object":{"key":"value"},"array":[1,2,3]}', result);
 				done();
 			}).done(undefined, done);
 		});
@@ -785,7 +785,7 @@ describe('bricks-net-api', function () {
 	describe('`JSONParse`', function () {
 		it('should parse JSON asynchronously', function (done) {
 			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
-			var json = JSON.stringify(object);
+			var json = '{"object":{"key":"value"},"array":[1,2,3]}';
 			when(
 				api.JSONParse(json)
 			).then(function (result) {

--- a/test/bricks-net-api.test.js
+++ b/test/bricks-net-api.test.js
@@ -8,6 +8,18 @@ describe('bricks-net-api', function () {
 	var HTTPRedirectLoopException = require('../lib/bricks-net-exceptions').HTTPRedirectLoopException;
 	var ConnectionResetByPeer = require('../lib/bricks-net-exceptions').ConnectionResetByPeer;
 	
+	it('should export `DefaultContentType` function', function () {
+		assert.equal('function', typeof api.DefaultContentType);
+	});
+	
+	it('should export `HTTPHeaders` function', function () {
+		assert.equal('function', typeof api.HTTPHeaders);
+	});
+	
+	it('should export `HTTPResponse` function', function () {
+		assert.equal('function', typeof api.HTTPResponse);
+	});
+	
 	it('should export `GET` function', function () {
 		assert.equal('function', typeof api.GET);
 	});
@@ -24,48 +36,171 @@ describe('bricks-net-api', function () {
 		assert.equal('function', typeof api.HTTP);
 	});
 	
-	it('should export `HTTPResponse` function', function () {
-		assert.equal('function', typeof api.HTTPResponse);
+	it('should export `JSON` function', function () {
+		assert.equal('function', typeof api.JSON);
 	});
 	
-	describe('`GET` function', function () {
-		it('should return an instance of `GET` class', function () {
-			assert.equal(true, api.GET("url") instanceof api.GET);
+	it('should export `JSONParse` function', function () {
+		assert.equal('function', typeof api.JSONParse);
+	});
+	
+	describe('`DefaultContentType`', function () {
+		it('should return "text/plain"', function () {
+			assert.strictEqual("text/plain", api.DefaultContentType());
+		});
+	});
+	
+	describe('`HTTPHeaders`', function () {
+		it('should create an instance of `HTTPHeaders` class', function () {
+			assert.equal(true, api.HTTPHeaders() instanceof api.HTTPHeaders);
 		});
 		
-		it('should set `url`', function () {
-			assert.equal('url', api.GET("url").url);
+		it('should have `headers` property which is an `Array`', function () {
+			assert.equal(true, Array.isArray(api.HTTPHeaders().headers));
 		});
 		
-		it('should `AllowRedirects` return an instance of `GET` class', function () {
-			assert.equal(true, api.GET("url").AllowRedirects() instanceof api.GET);
+		it('should have `Set` method', function () {
+			assert.equal('function', typeof api.HTTPHeaders().Set);
 		});
 		
-		it('should `AllowRedirects` set `allow_redirects`', function () {
-			assert.equal(true, api.GET("url").AllowRedirects().allow_redirects);
-			assert.equal(false, api.GET("url").AllowRedirects(false).allow_redirects);
-			assert.equal(true, api.GET("url").AllowRedirects(true).allow_redirects);
-		});
-		
-		it('should `UserAgent` return an instance of `GET` class', function () {
-			assert.equal(true, api.GET("url").UserAgent("USERAGENT") instanceof api.GET);
-		});
-		
-		it('should `UserAgent` set `custom_user_agent`', function () {
-			assert.equal("USERAGENT", api.GET("url").UserAgent("USERAGENT").custom_user_agent);
-			assert.equal("", api.GET("url").UserAgent("").custom_user_agent);
-		});
-		
-		it('should `UserAgent` throw if argument not set', function () {
-			assert.throws(function () {
-				api.GET("url").UserAgent();
+		describe('`Set` method', function () {
+			it('should add headers and allow chaining', function () {
+				var headers = api.HTTPHeaders();
+				
+				var ret = headers.Set('Custom', 'Header');
+				
+				assert.strictEqual(headers, ret);
+				
+				assert.deepEqual([
+					{
+						first: 'Custom',
+						second: 'Header'
+					}
+				], ret.headers);
+				
+				headers.Set('Custom2', 'Header2');
+				
+				assert.deepEqual([
+					{
+						first: 'Custom',
+						second: 'Header'
+					},
+					{
+						first: 'Custom2',
+						second: 'Header2'
+					}
+				], ret.headers);
 			});
 		});
 	});
 	
-	describe('`POST` function', function () {
-		it('should return an instance of `POST` class', function () {
+	describe('`GET`', function () {
+		it('should create an instance of `GET` class', function () {
+			assert.equal(true, api.GET("url") instanceof api.GET);
+		});
+		
+		it('should set `url`', function () {
+			assert.strictEqual('url', api.GET("url").url);
+		});
+		
+		it('should set `extra_headers`', function () {
+			assert.deepEqual([
+				{
+					first: 'Custom',
+					second: 'Header'
+				}
+			], api.GET("url", api.HTTPHeaders().Set('Custom', 'Header')).extra_headers);
+		});
+		
+		it('should throw on invalid arguments', function () {
+			assert.throws(function () {
+				api.GET();
+			});
+			assert.throws(function () {
+				api.GET(1);
+			});
+			assert.throws(function () {
+				api.GET("url", "invalid argument");
+			});
+			assert.throws(function () {
+				api.GET("url", api.HTTPHeaders(), "invalid argument");
+			});
+		});
+		
+		describe('`AllowRedirects` method', function () {
+			it('should allow chaining', function () {
+				var ret = api.GET("url");
+				assert.strictEqual(ret, ret.AllowRedirects());
+			});
+			
+			it('should set `allow_redirects`', function () {
+				assert.strictEqual(true, api.GET("url").AllowRedirects().allow_redirects);
+				assert.strictEqual(false, api.GET("url").AllowRedirects(false).allow_redirects);
+				assert.strictEqual(true, api.GET("url").AllowRedirects(true).allow_redirects);
+			});
+		});
+		
+		describe('`UserAgent` method', function () {
+			it('should allow chaining', function () {
+				var ret = api.GET("url");
+				assert.strictEqual(ret, ret.UserAgent("USERAGENT"));
+			});
+		
+			it('should set `custom_user_agent`', function () {
+				assert.strictEqual("USERAGENT", api.GET("url").UserAgent("USERAGENT").custom_user_agent);
+				assert.strictEqual("", api.GET("url").UserAgent("").custom_user_agent);
+			});
+		
+			it('should throw if argument not set', function () {
+				assert.throws(function () {
+					api.GET("url").UserAgent();
+				});
+			});
+		});
+	});
+	
+	describe('`POST`', function () {
+		it('should create an instance of `POST` class', function () {
 			assert.equal(true, api.POST("url") instanceof api.POST);
+		});
+		
+		it('should set `url`', function () {
+			assert.strictEqual('url', api.POST("url").url);
+		});
+		
+		it('should set `body` and `has_body` (string)', function () {
+			assert.strictEqual('body', api.POST("url", "body").body);
+			
+			assert.strictEqual(false, api.POST("url").has_body);
+			assert.strictEqual(true, api.POST("url", "body").has_body);
+			assert.strictEqual(true, api.POST("url", "").has_body);
+		});
+		
+		it('should set `body` and `has_body` (JSON)', function () {
+			var object = { test: [ 1, 2, 3 ] };
+			var body = JSON.stringify({ data: object });
+			assert.strictEqual(body, api.POST("url", object).body);
+			assert.strictEqual(true, api.POST("url", object).has_body);
+		});
+		
+		it('should set default `content_type`', function () {
+			assert.strictEqual(api.DefaultContentType(), api.POST("url").content_type);
+			assert.strictEqual(api.DefaultContentType(), api.POST("url", "body").content_type);
+			assert.strictEqual("application/json", api.POST("url", {}).content_type);
+		});
+		
+		it('should set custom `content_type`', function () {
+			assert.strictEqual("content/type", api.POST("url", "body", "content/type").content_type);
+			assert.strictEqual("content/type", api.POST("url", {}, "content/type").content_type);
+		});
+		
+		it('should set `extra_headers`', function () {
+			assert.deepEqual([
+				{
+					first: 'Custom',
+					second: 'Header'
+				}
+			], api.POST("url", "body", "content/type", api.HTTPHeaders().Set('Custom', 'Header')).extra_headers);
 		});
 		
 		it('should throw on invalid arguments', function () {
@@ -78,16 +213,19 @@ describe('bricks-net-api', function () {
 			assert.throws(function () {
 				api.POST("url", "body", "content/type", "invalid argument");
 			});
+			assert.throws(function () {
+				api.POST("url", "body", "content/type", HTTPHeaders(), "invalid argument");
+			});
 		});
 	});
 	
-	describe('`POSTFromFile` function', function () {
-		it('should return an instance of `POSTFromFile` class', function () {
+	describe('`POSTFromFile`', function () {
+		it('should create an instance of `POSTFromFile` class', function () {
 			assert.equal(true, api.POSTFromFile("url", __filename, "application/javascript") instanceof api.POSTFromFile);
 		});
 	});
 	
-	describe('`HTTP` function', function () {
+	describe('`HTTP`', function () {
 		var KBYTES_IN_BYTES = 1000;
 		var MBYTES_IN_BYTES = 1000 * KBYTES_IN_BYTES;
 		var largeBodyLength = 50 * MBYTES_IN_BYTES;
@@ -631,4 +769,30 @@ describe('bricks-net-api', function () {
 			}).done(undefined, done);
 		});
 	});
+	
+	describe('`JSON`', function () {
+		it('should serialize into JSON asynchronously', function (done) {
+			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
+			when(
+				api.JSON(object)
+			).then(function (result) {
+				assert.strictEqual(JSON.stringify(object), result);
+				done();
+			}).done(undefined, done);
+		});
+	});
+	
+	describe('`JSONParse`', function () {
+		it('should parse JSON asynchronously', function (done) {
+			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
+			var json = JSON.stringify(object);
+			when(
+				api.JSONParse(json)
+			).then(function (result) {
+				assert.deepEqual(object, result);
+				done();
+			}).done(undefined, done);
+		});
+	});
+	
 });

--- a/test/bricks-net-url.test.js
+++ b/test/bricks-net-url.test.js
@@ -12,7 +12,24 @@ describe('bricks-net-url', function () {
 		assert.equal('function', typeof EmptyURLException);
 	});
 	
-	describe('`URL` function', function () {
+	describe('`URL`', function () {
+		it('should create default URL from empty arguments', function () {
+			var url = URL();
+			assert.strictEqual('http', url.scheme);
+			assert.strictEqual('', url.host);
+			assert.strictEqual(0, url.port);
+			assert.strictEqual('/', url.path);
+			assert.deepEqual([], url.parameters_vector);
+			assert.equal('object', typeof url.query);
+			assert.equal('function', typeof url.query.has);
+			assert.equal('function', typeof url.query.get);
+			assert.strictEqual(false, url.query.has('foo'));
+			assert.strictEqual('', url.query.get('foo'));
+			assert.strictEqual('DEFAULT', url.query.get('foo', 'DEFAULT'));
+			assert.strictEqual('', url.fragment);
+			assert.strictEqual('', url.url_without_parameters);
+		});
+		
 		// Read the C++ tests for `URL`.
 		var cppTest = require('fs').readFileSync(__dirname + '/bricks-net-url.test.cc');
 		
@@ -28,17 +45,17 @@ describe('bricks-net-url', function () {
 		
 		cppTest = cppTest.replace(/EXPECT_EQ\("((?:[^"\\]|\\.)*)", ([a-zA-Z0-9_]+)\.query\["((?:[^"\\]|\\.)*)"\]\);/gm, 'assert.equal("$1", $2.query.get("$3"));');
 		
-		cppTest = cppTest.replace(/EXPECT_EQ\(/gm, 'assert.equal(');
+		cppTest = cppTest.replace(/EXPECT_EQ\(/gm, 'assert.strictEqual(');
 		cppTest = cppTest.replace(/ASSERT_THROW\((.+?), ([a-zA-Z0-9_]+)\);/gm, 'assert.throws(function () { $1; }, $2);');
 		cppTest = cppTest.replace(/URL u;/gm, 'var u;');
 		cppTest = cppTest.replace(/URL u\(/gm, 'var u = URL(');
 		
-		/* DEBUG *
-		// Print the source code we're going to evaluate, with line numbers for debugging.
-		console.log(cppTest.split('\n').map(function (line, index) {
-			return ((index+1) + '| ' + line);
-		}).join('\n'));
-		// */
+		if (process.env.NODE_ENV === 'development') {
+			// Print the source code we're going to evaluate, with line numbers for debugging.
+			console.log(cppTest.split('\n').map(function (line, index) {
+				return ((index+1) + '| ' + line);
+			}).join('\n'));
+		}
 		
 		// Run the C++ tests.
 		eval(cppTest);

--- a/test/cpp-arguments.test.js
+++ b/test/cpp-arguments.test.js
@@ -127,6 +127,17 @@ describe('cpp-arguments', function () {
 			], []);
 		});
 		
+		it('should select empty signature if other ones do not match', function () {
+			var optionalArgumentSignatureCalled = 0;
+			cppExceptions.assert('TestMethod', [
+				emptySignature,
+				[].concat(optionalArgumentSignature).concat(function () {
+					++optionalArgumentSignatureCalled;
+				})
+			], []);
+			assert.equal(0, optionalArgumentSignatureCalled);
+		});
+		
 		it('should throw if too many arguments for empty signature', function () {
 			assert.throws(function () {
 				cppExceptions.assert('TestMethod', [

--- a/test/cpp-arguments.test.js
+++ b/test/cpp-arguments.test.js
@@ -250,6 +250,7 @@ describe('cpp-arguments', function () {
 				{ test: "abc" },
 				123
 			];
+			// HACK(sompylasar): Using `JSON.stringify` here as a quick checksum for a nested object.
 			var signaturesChecksum = JSON.stringify(signatures);
 			var valuesChecksum = JSON.stringify(values);
 			


### PR DESCRIPTION
- Added support for request chaining.
  - Added AST transform to wrap function call arguments into promises.
  - Added more comments.
- Added a cerealizable-like `DemoObject` for the JSON-related examples.
- Extended the HTTP client API to send custom headers.
  - @dkorolev Bricks API should reflect this extension. I'd also rename `HTTPHeaders().Set()` to `HTTPHeaders().Add()` (according to its actual behavior) - not renamed in this PR yet.
- Added more examples to the README.
- Added more tests.
