### PR TITLE
Fix JSON serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install
 
 ## Usage
 
-#### Start the interactive shell
+#### Start the interactive REPL
 ```bash
 node run
 ```
@@ -23,7 +23,7 @@ The command prompt `KnowSheet> ` will appear.
 ```bash
 echo 'HTTP(GET("http://httpbin.org/get?query=1")).body' | node run
 ```
-If `stdin` is not a `tty`, the shell starts in a non-interactive mode.
+If `stdin` is not a `tty`, the REPL starts in a non-interactive mode.
 
 #### Evaluate and pass the result to another command
 ```bash
@@ -39,8 +39,7 @@ The command prompt `Bricks> ` will appear.
 
 ### HTTP client
 
-* Bricks provides utilities to perform HTTP requests.
-* By default, the redirects are forbidden and result in an error. They can be enabled per request.
+Bricks provides utilities to perform HTTP requests. By default, the redirects are forbidden and result in an error; they can be enabled per request.
 
 #### Perform an HTTP GET request
 ```
@@ -75,17 +74,17 @@ KnowSheet> HTTP(POST("http://httpbin.org/post", "BODY", "text/plain", HTTPHeader
 
 ### HTTP server
 
-* Bricks maintains a single server per port.
-* Each server accepts connections since start till the process exits.
-* There can only be a single handler for a given path.
-* The calls to the server methods can be chained.
-* The handler lambda syntax in the REPL mimics C++11 to a certain extent -- no full lambda support guaranteed.
+Bricks provides utilities to create simple HTTP-based servers.
 
 #### Start an HTTP server
 ```
 KnowSheet> HTTP(2015)
 // KnowSheet Bricks HTTPServer at port 2015
 ```
+
+* Bricks maintains a single server per port. The first call to `HTTP` with a port number starts an HTTP server on that port and returns an instance of the server. The next calls with the same port reference the started server.
+* The calls to the server methods can be chained (each method returns the server instance).
+* Each server accepts connections since start till the process exits (there is no way to explicitly stop it).
 
 #### Register an endpoint on an HTTP server
 ```
@@ -97,6 +96,9 @@ pong
 --------------------------------------------------------------------------------
 (32ms)
 ```
+
+* There can only be a single handler for an endpoint path. The handler is expected to dispatch by HTTP method (verb).
+* The handler lambda syntax in the REPL mimics C++11 to a certain extent -- no full lambda support guaranteed.
 
 #### Unregister an endpoint from an HTTP server
 ```
@@ -117,17 +119,21 @@ BODY
 
 ### JSON
 
+Bricks provides utilities to parse [JSON](http://json.org/) strings into instances of serializable types and serialize them back into JSON. The REPL mimics Bricks C++ syntax to a certain extent.
+
 #### POST a JSON-encoded instance of a serializable type
 ```
 KnowSheet> HTTP(POST("http://httpbin.org/post", DemoObject())).body
 ```
-<sup>The syntax mimics C++ Bricks exactly, as long as `DemoObject` is defined as a serializable type.</sup>
+
+The syntax mimics C++ Bricks exactly, as long as `DemoObject` is defined as a serializable type.
 
 #### Parse a JSON response into an object
 ```
 KnowSheet> ParseJSON(HTTP(GET("http://httpbin.org/get?query=1")).body).args
 ```
-<sup>The syntax deviates from C++ Bricks which requires a serializable type specified for the response object, for example, `auto response = ParseJSON<HttpbinGetResponse>(response_text);` or `HttpbinGetResponse response; ParseJSON(response_text, response);`.</sup>
+
+The syntax deviates from C++ Bricks which requires a serializable type specified for the response object, for example, `auto response = ParseJSON<HttpbinGetResponse>(response_text);` or `HttpbinGetResponse response; ParseJSON(response_text, response);`.
 
 ### Advanced examples
 
@@ -135,4 +141,5 @@ KnowSheet> ParseJSON(HTTP(GET("http://httpbin.org/get?query=1")).body).args
 ```
 KnowSheet> ParseJSON(HTTP(POST("http://httpbin.org/post", ParseJSON(HTTP(GET("http://httpbin.org/get?query=1")).body))).body)
 ```
-<sup>In C++ Bricks, the calls to `ParseJSON` would be templated by serializable types of the response objects, for example, `ParseJSON<HttpbinPostResponse>( /* ... */ )`.</sup>
+
+In C++ Bricks, the calls to `ParseJSON` would be templated by serializable types of the response objects, for example, `ParseJSON<HttpbinPostResponse>( /* ... */ )`.

--- a/lib/bricks-evaluate.js
+++ b/lib/bricks-evaluate.js
@@ -75,6 +75,8 @@ function createContext() {
 		this.demo_map = {
 			"key": "value"
 		};
+		
+		require('./bricks-json').Serializable.call(this);
 	}
 	
 	/**

--- a/lib/bricks-json.js
+++ b/lib/bricks-json.js
@@ -4,8 +4,32 @@ var inspect = require('util').inspect;
 
 var cppArguments = require('./cpp-arguments');
 
+var JavaScriptJSON = global.JSON;
 
-exports.JSON = function () {
+
+function Serializable() {
+	var _this = this;
+	
+	Object.defineProperties(_this, {
+		serialize: {
+			configurable: false,
+			enumerable: false,
+			writable: false,
+			value: function (ar) {
+				Object.keys(_this).forEach(function (key) {
+					if (typeof _this[key] === 'function') {
+						return;
+					}
+					
+					ar[key] = _this[key];
+				});
+			}
+		}
+	});
+}
+
+
+function JSON() {
 	return cppArguments.assert('JSON', [
 		[
 			cppArguments.assertion('object', 'T&&', 'object'),
@@ -14,42 +38,40 @@ exports.JSON = function () {
 				if (typeof object.serialize !== 'function') {
 					throw new Error('JSON: Object is not serializable: ' + inspect(object));
 				}
-		
+				
+				var ar = {};
+				
 				if (typeof name === 'string') {
-					object = Object.create({
-						serialize: function () {
-							return object;
-						}
-					});
-			
-					object[name] = ret;
+					ar[name] = {};
+					object.serialize(ar[name]);
 				}
-		
-				return JSON.stringify(object.serialize());
+				else {
+					object.serialize(ar);
+				}
+				
+				return JavaScriptJSON.stringify(ar);
 			}
 		]
 	], arguments);
-};
+}
 
-exports.ParseJSON = function () {
+
+function ParseJSON() {
 	return cppArguments.assert('ParseJSON', [
 		[
 			cppArguments.assertion('string', 'const std::string&', 'str'),
 			function (str) {
-				var parsed = JSON.parse(str);
+				var object = JavaScriptJSON.parse(str);
 				
-				var object = Object.create({
-					serialize: function () {
-						return object;
-					}
-				});
-				
-				for (var x in parsed) {
-					object[x] = parsed[x];
-				}
+				Serializable.call(object);
 				
 				return object;
 			}
 		]
 	], arguments);
-};
+}
+
+
+exports.Serializable = Serializable;
+exports.JSON = JSON;
+exports.ParseJSON = ParseJSON;

--- a/lib/bricks-json.js
+++ b/lib/bricks-json.js
@@ -1,21 +1,55 @@
 'use strict';
 
-var when = require('when');
+var inspect = require('util').inspect;
+
+var cppArguments = require('./cpp-arguments');
 
 
-exports.JSON = function (object, name) {
-	return when(object).then(function (ret) {
-		var object = ret;
-		if (typeof name === 'string') {
-			object = {};
-			object[name] = ret;
-		}
-		return JSON.stringify(object);
-	});
+exports.JSON = function () {
+	return cppArguments.assert('JSON', [
+		[
+			cppArguments.assertion('object', 'T&&', 'object'),
+			cppArguments.assertion('string', 'const std::string&', 'name', cppArguments.ASSERTION_MODE_OPTIONAL),
+			function (object, name) {
+				if (typeof object.serialize !== 'function') {
+					throw new Error('JSON: Object is not serializable: ' + inspect(object));
+				}
+		
+				if (typeof name === 'string') {
+					object = Object.create({
+						serialize: function () {
+							return object;
+						}
+					});
+			
+					object[name] = ret;
+				}
+		
+				return JSON.stringify(object.serialize());
+			}
+		]
+	], arguments);
 };
 
-exports.ParseJSON = function (arg) {
-	return when(arg).then(function (ret) {
-		return JSON.parse(ret);
-	});
+exports.ParseJSON = function () {
+	return cppArguments.assert('ParseJSON', [
+		[
+			cppArguments.assertion('string', 'const std::string&', 'str'),
+			function (str) {
+				var parsed = JSON.parse(str);
+				
+				var object = Object.create({
+					serialize: function () {
+						return object;
+					}
+				});
+				
+				for (var x in parsed) {
+					object[x] = parsed[x];
+				}
+				
+				return object;
+			}
+		]
+	], arguments);
 };

--- a/lib/bricks-json.js
+++ b/lib/bricks-json.js
@@ -8,17 +8,32 @@ var JavaScriptJSON = global.JSON;
 
 
 function Serializable() {
-	var _this = this;
-	
-	Object.defineProperties(_this, {
+	Object.defineProperties(this, {
 		serialize: {
 			configurable: false,
 			enumerable: false,
 			writable: false,
-			value: function (ar) {
+			value: this.serialize || function (ar) {
+				var _this = this;
+				
 				Object.keys(_this).forEach(function (key) {
 					if (typeof _this[key] === 'function') {
+						// Ignore functions.
 						return;
+					}
+					
+					if (typeof _this[key] === 'object') {
+						if (Array.isArray(_this[key])) {
+							ar[key] = [].slice.call(_this[key]);
+						}
+						else if (_this[key] && typeof _this[key].serialize === 'function') {
+							ar[key] = {};
+							_this[key].serialize(ar[key]);
+						}
+						else {
+							// Ignore objects if they are not serializable.
+							return;
+						}
 					}
 					
 					ar[key] = _this[key];
@@ -46,7 +61,8 @@ function JSON() {
 					object.serialize(ar[name]);
 				}
 				else {
-					object.serialize(ar);
+					ar["value0"] = {};
+					object.serialize(ar["value0"]);
 				}
 				
 				return JavaScriptJSON.stringify(ar);

--- a/lib/bricks-net-http-server.js
+++ b/lib/bricks-net-http-server.js
@@ -74,12 +74,16 @@ function Request(connection) {
 			value: function () {
 				return 'Request(' + connection + ')';
 			}
+		},
+		SendChunkedResponse: {
+			configurable: false,
+			enumerable: false,
+			writable: false,
+			value: function () {
+				return _this.connection.SendChunkedHTTPResponse();
+			}
 		}
 	});
-	
-	_this.SendChunkedResponse = function () {
-		return _this.connection.SendChunkedHTTPResponse();
-	};
 	
 	_this.connection = connection;
 	var http_data = _this.http_data = connection.HTTPRequest();

--- a/lib/bricks-net-url.js
+++ b/lib/bricks-net-url.js
@@ -245,7 +245,20 @@ function URL() {
 	function QueryParameters(parameters_vector) {
 		var _this = this;
 		
-		_this.parameters_ = {};
+		Object.defineProperties(_this, {
+			parameters_vector_: {
+				configurable: false,
+				enumerable: false,
+				writable: false,
+				value: parameters_vector
+			},
+			parameters_: {
+				configurable: false,
+				enumerable: false,
+				writable: false,
+				value: {}
+			}
+		});
 		
 		parameters_vector.forEach(function (param) {
 			_this.parameters_[param.first] = param.second;
@@ -331,12 +344,24 @@ function URL() {
 	], arguments);
 	
 	
-	this.ComposeParameters = function () {
-		return URLParametersExtractor_ComposeParameters();
-	};
-	this.ComposeURL = function () {
-		return URLWithoutParametersParser_ComposeURL() + URLParametersExtractor_ComposeParameters();
-	};
+	Object.defineProperties(_this, {
+		ComposeParameters: {
+			configurable: false,
+			enumerable: false,
+			writable: false,
+			value: function () {
+				return URLParametersExtractor_ComposeParameters();
+			}
+		},
+		ComposeURL: {
+			configurable: false,
+			enumerable: false,
+			writable: false,
+			value: function () {
+				return URLWithoutParametersParser_ComposeURL() + URLParametersExtractor_ComposeParameters();
+			}
+		}
+	});
 }
 
 exports.URL = URL;

--- a/lib/cpp-arguments.js
+++ b/lib/cpp-arguments.js
@@ -135,7 +135,13 @@ var baseAssertions = {
 	},
 	object: {
 		check: function (value) {
+			return (typeof value === 'object' && value !== null);
+		}
+	},
+	plainObject: {
+		check: function (value) {
 			return (typeof value === 'object'
+				&& value !== null
 				&& (
 					value === Object_prototype
 					|| Object_getPrototypeOf(value) === Object_prototype

--- a/test/bricks-json.test.js
+++ b/test/bricks-json.test.js
@@ -1,0 +1,90 @@
+var assert = require('assert');
+
+var inspect = require('util').inspect;
+
+describe('bricks-json', function () {
+	var api = require('../lib/bricks-json');
+	
+	it('should export `JSON` function', function () {
+		assert.equal('function', typeof api.JSON);
+	});
+	
+	it('should export `ParseJSON` function', function () {
+		assert.equal('function', typeof api.ParseJSON);
+	});
+	
+	it('should export `Serializable` function', function () {
+		assert.equal('function', typeof api.Serializable);
+	});
+	
+	describe('`JSON`', function () {
+		it('should serialize a serializable into JSON', function () {
+			function TestObject() {
+				function InnerObject() {
+					api.Serializable.call(this);
+					
+					this.key = "value";
+				}
+				
+				api.Serializable.call(this);
+				
+				this.object = new InnerObject();
+				this.array = [ 1, 2, 3 ];
+			}
+			
+			var object = new TestObject();
+			var expected = '{"value0":{"object":{"key":"value"},"array":[1,2,3]}}';
+			var actual = api.JSON(object);
+			
+			assert.strictEqual(expected, actual);
+		});
+		
+		it('should throw for non-serializable', function () {
+			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
+			
+			assert.throws(function () {
+				api.JSON(object);
+			});
+		});
+		
+		it('should serialize under the passed root name', function () {
+			function TestObject() {
+				api.Serializable.call(this);
+			}
+			
+			var object = new TestObject();
+			var expected = '{"test_name":{}}';
+			var actual = api.JSON(object, "test_name");
+			
+			assert.strictEqual(expected, actual);
+		});
+		
+		it('should ignore non-serializable properties', function () {
+			function TestObject() {
+				api.Serializable.call(this);
+				
+				this.non_serializable_object = {
+					"key": "value"
+				};
+				
+				this.non_serializable_function = function () {};
+			}
+			
+			var object = new TestObject();
+			var expected = '{"value0":{}}';
+			var actual = api.JSON(object);
+			
+			assert.strictEqual(expected, actual);
+		});
+	});
+	
+	describe('`ParseJSON`', function () {
+		it('should parse JSON into a serializable', function () {
+			var json = '{"object":{"key":"value"},"array":[1,2,3]}';
+			var expected = { object: { key: "value" }, array: [ 1, 2, 3 ] };
+			var actual = api.ParseJSON(json);
+			assert.deepEqual(expected, actual);
+			assert.equal('function', typeof actual.serialize);
+		});
+	});
+});

--- a/test/bricks-net-api.test.js
+++ b/test/bricks-net-api.test.js
@@ -108,27 +108,31 @@ describe('bricks-net-api', function () {
 	});
 	
 	describe('`JSON`', function () {
-		it('should serialize into JSON asynchronously', function (done) {
+		it('should serialize a serializable into JSON', function () {
 			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
-			when(
+			object.serialize = function () {
+				return object;
+			};
+			var expected = '{"object":{"key":"value"},"array":[1,2,3]}';
+			var actual = api.JSON(object);
+			assert.strictEqual(expected, actual);
+		});
+		
+		it('should throw for non-serializable', function () {
+			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
+			assert.throws(function () {
 				api.JSON(object)
-			).then(function (result) {
-				assert.strictEqual('{"object":{"key":"value"},"array":[1,2,3]}', result);
-				done();
-			}).done(undefined, done);
+			});
 		});
 	});
 	
 	describe('`ParseJSON`', function () {
-		it('should parse JSON asynchronously', function (done) {
-			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
+		it('should parse JSON into a serializable', function () {
 			var json = '{"object":{"key":"value"},"array":[1,2,3]}';
-			when(
-				api.ParseJSON(json)
-			).then(function (result) {
-				assert.deepEqual(object, result);
-				done();
-			}).done(undefined, done);
+			var expected = { object: { key: "value" }, array: [ 1, 2, 3] };
+			var actual = api.ParseJSON(json);
+			assert.deepEqual(expected, actual);
+			assert.equal('function', typeof actual.serialize);
 		});
 	});
 	

--- a/test/bricks-net-api.test.js
+++ b/test/bricks-net-api.test.js
@@ -107,33 +107,6 @@ describe('bricks-net-api', function () {
 		});
 	});
 	
-	describe('`JSON`', function () {
-		it('should serialize a serializable into JSON', function () {
-			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
-			require('../lib/bricks-json').Serializable.call(object);
-			var expected = '{"object":{"key":"value"},"array":[1,2,3]}';
-			var actual = api.JSON(object);
-			assert.strictEqual(expected, actual);
-		});
-		
-		it('should throw for non-serializable', function () {
-			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
-			assert.throws(function () {
-				api.JSON(object)
-			});
-		});
-	});
-	
-	describe('`ParseJSON`', function () {
-		it('should parse JSON into a serializable', function () {
-			var json = '{"object":{"key":"value"},"array":[1,2,3]}';
-			var expected = { object: { key: "value" }, array: [ 1, 2, 3] };
-			var actual = api.ParseJSON(json);
-			assert.deepEqual(expected, actual);
-			assert.equal('function', typeof actual.serialize);
-		});
-	});
-	
 	describe('`GET`', function () {
 		it('should create an instance of `GET` class', function () {
 			assert.equal(true, api.GET("url") instanceof api.GET);

--- a/test/bricks-net-api.test.js
+++ b/test/bricks-net-api.test.js
@@ -110,9 +110,7 @@ describe('bricks-net-api', function () {
 	describe('`JSON`', function () {
 		it('should serialize a serializable into JSON', function () {
 			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
-			object.serialize = function () {
-				return object;
-			};
+			require('../lib/bricks-json').Serializable.call(object);
 			var expected = '{"object":{"key":"value"},"array":[1,2,3]}';
 			var actual = api.JSON(object);
 			assert.strictEqual(expected, actual);

--- a/test/cpp-arguments.test.js
+++ b/test/cpp-arguments.test.js
@@ -21,19 +21,23 @@ describe('cpp-arguments', function () {
 	
 	describe('`assertion` function', function () {
 		it('should create assertions for base assertion types', function () {
+			function TestObject() {}
+			
 			var baseAssertions = {
 				'bool': false,
 				'string': "abc",
 				'int': 123,
 				'double': 0.5,
-				'object': { test: { something: "foo" } }
+				'object': new TestObject(),
+				'plainObject': { test: { something: "foo" } }
 			};
 			var baseAssertionsNegative = {
 				'bool': "abc",
 				'string': 123,
 				'int': 0.5,
 				'double': { test: { something: "foo" } },
-				'object': false
+				'object': false,
+				'plainObject': new TestObject()
 			};
 			
 			Object.keys(baseAssertions).forEach(function (assertionName) {


### PR DESCRIPTION
- Changed JSON, ParseJSON to be synchronous. They will be wrapped with `when(...).then(...)` during evaluation.
- Changed JSON, ParseJSON to only accept Serializable.
- Added "value0" if no root name is specified.
- Ignore non-serializable objects.
- Hide on-object methods via property descriptors.
- Added more tests, moved the JSON tests into a separate file.
