### PR TITLE
Refactored REPL expression transpiling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ KnowSheet> HTTP(2015)
 // KnowSheet Bricks HTTPServer at port 2015
 ```
 
-* Bricks maintains a single server per port. The first call to `HTTP` with a port number starts an HTTP server on that port and returns an instance of the server. The next calls with the same port reference the started server.
+* Bricks maintains a single server per port. No need to explicitly start a server: the first call to `HTTP` with a port number starts a server on that port and returns an instance of the server; the next calls with the same port reference the started server.
 * The calls to the server methods can be chained (each method returns the server instance).
-* Each server accepts connections since start till the process exits (there is no way to explicitly stop it).
+* Each server accepts connections since its start till the process exits. No need to explicitly stop it.
 
 #### Register an endpoint on an HTTP server
 ```
@@ -98,7 +98,7 @@ pong
 ```
 
 * There can only be a single handler for an endpoint path. The handler is expected to dispatch by HTTP method (verb).
-* The handler lambda syntax in the REPL mimics C++11 to a certain extent -- no full lambda support guaranteed.
+* The handler lambda syntax in the REPL mimics C++11 to a certain extent -- no full lambda support is guaranteed.
 
 #### Unregister an endpoint from an HTTP server
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install
 
 ## Usage
 
-#### Start the interactive shell
+#### Start the interactive REPL
 ```bash
 node run
 ```
@@ -23,7 +23,7 @@ The command prompt `KnowSheet> ` will appear.
 ```bash
 echo 'HTTP(GET("http://httpbin.org/get?query=1")).body' | node run
 ```
-If `stdin` is not a `tty`, the shell starts in a non-interactive mode.
+If `stdin` is not a `tty`, the REPL starts in a non-interactive mode.
 
 #### Evaluate and pass the result to another command
 ```bash
@@ -39,8 +39,7 @@ The command prompt `Bricks> ` will appear.
 
 ### HTTP client
 
-* Bricks provides utilities to perform HTTP requests.
-* By default, the redirects are forbidden and result in an error. They can be enabled per request.
+Bricks provides utilities to perform HTTP requests. By default, the redirects are forbidden and result in an error; they can be enabled per request.
 
 #### Perform an HTTP GET request
 ```
@@ -75,17 +74,17 @@ KnowSheet> HTTP(POST("http://httpbin.org/post", "BODY", "text/plain", HTTPHeader
 
 ### HTTP server
 
-* Bricks maintains a single server per port.
-* Each server accepts connections since start till the process exits.
-* There can only be a single handler for a given path.
-* The calls to the server methods can be chained.
-* The handler lambda syntax in the REPL mimics C++11 to a certain extent -- no full lambda support guaranteed.
+Bricks provides utilities to create simple HTTP-based servers.
 
 #### Start an HTTP server
 ```
 KnowSheet> HTTP(2015)
 // KnowSheet Bricks HTTPServer at port 2015
 ```
+
+* Bricks maintains a single server per port. The first call to `HTTP` with a port number starts an HTTP server on that port and returns an instance of the server. The next calls with the same port reference the started server.
+* The calls to the server methods can be chained (each method returns the server instance).
+* Each server accepts connections since start till the process exits (there is no way to explicitly stop it).
 
 #### Register an endpoint on an HTTP server
 ```
@@ -97,6 +96,9 @@ pong
 --------------------------------------------------------------------------------
 (32ms)
 ```
+
+* There can only be a single handler for an endpoint path. The handler is expected to dispatch by HTTP method (verb).
+* The handler lambda syntax in the REPL mimics C++11 to a certain extent -- no full lambda support guaranteed.
 
 #### Unregister an endpoint from an HTTP server
 ```
@@ -117,17 +119,21 @@ BODY
 
 ### JSON
 
+Bricks provides utilities to parse [JSON](http://json.org/) strings into instances of serializable types and serialize them back into JSON. The REPL mimics Bricks C++ syntax to a certain extent.
+
 #### POST a JSON-encoded instance of a serializable type
 ```
 KnowSheet> HTTP(POST("http://httpbin.org/post", DemoObject())).body
 ```
-<sup>The syntax mimics C++ Bricks exactly, as long as `DemoObject` is defined as a serializable type.</sup>
+
+The syntax mimics C++ Bricks exactly, as long as `DemoObject` is defined as a serializable type.
 
 #### Parse a JSON response into an object
 ```
 KnowSheet> ParseJSON(HTTP(GET("http://httpbin.org/get?query=1")).body).args
 ```
-<sup>The syntax deviates from C++ Bricks which requires a serializable type specified for the response object, for example, `auto response = ParseJSON<HttpbinGetResponse>(response_text);` or `HttpbinGetResponse response; ParseJSON(response_text, response);`.</sup>
+
+The syntax deviates from C++ Bricks which requires a serializable type specified for the response object, for example, `auto response = ParseJSON<HttpbinGetResponse>(response_text);` or `HttpbinGetResponse response; ParseJSON(response_text, response);`.
 
 ### Advanced examples
 
@@ -135,4 +141,5 @@ KnowSheet> ParseJSON(HTTP(GET("http://httpbin.org/get?query=1")).body).args
 ```
 KnowSheet> ParseJSON(HTTP(POST("http://httpbin.org/post", ParseJSON(HTTP(GET("http://httpbin.org/get?query=1")).body))).body)
 ```
-<sup>In C++ Bricks, the calls to `ParseJSON` would be templated by serializable types of the response objects, for example, `ParseJSON<HttpbinPostResponse>( /* ... */ )`.</sup>
+
+In C++ Bricks, the calls to `ParseJSON` would be templated by serializable types of the response objects, for example, `ParseJSON<HttpbinPostResponse>( /* ... */ )`.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The command prompt `Bricks> ` will appear.
 
 ### HTTP client
 
-Bricks provides utilities to perform HTTP requests. By default, the redirects are forbidden and result in an error; they can be enabled per request.
+Bricks provides utilities to perform HTTP requests. By default, redirects are forbidden and result in an error; they can be enabled per request.
 
 #### Perform an HTTP GET request
 ```

--- a/lib/bricks-evaluate.js
+++ b/lib/bricks-evaluate.js
@@ -1,11 +1,31 @@
 'use strict';
 
+var inspect = require('util').inspect;
+
+// @see https://github.com/brianmcd/contextify#requirevm-vs-contextify
+var USE_CONTEXTIFY = true;
 var vm = require('vm');
+var Contextify = require('contextify');
 
 // Promise library for handling sync and async REPL evaluations the same way.
 var when = require('when');
 
 var extend = require('./extend');
+
+var transforms = require('./promise-transforms');
+
+var api = require('./bricks-net-api');
+
+
+function _hideContextProperty(context, name, value) {
+	Object.defineProperty(context, name, {
+		configurable: true,
+		enumerable: (name in api ? true : false),
+		writable: ((name in global) && !(name in api)),
+		value: (name in api ? api[name] : value)
+	});
+}
+
 
 /**
  * Creates the context that contains the KnowSheet Bricks API.
@@ -13,27 +33,29 @@ var extend = require('./extend');
  * @return {vm.Context} The contextified object ready to use in the `vm` code runner.
  */
 function createContext() {
-	var context = vm.createContext();
+	var context;
 	
-	var api = require('./bricks-net-api');
-	
-	
-	function hideContextProperty(x) {
-		Object.defineProperty(context, x, {
-			configurable: false,
-			enumerable: (x in api ? true : false),
-			writable: false,
-			value: (x in api ? api[x] : undefined)
-		});
+	if (USE_CONTEXTIFY) {
+		context = Contextify({});
+		
+		_hideContextProperty(context, 'run', context.run);
+		_hideContextProperty(context, 'getGlobal', context.getGlobal);
+		_hideContextProperty(context, 'dispose', context.dispose);
+	}
+	else {
+		context = vm.createContext();
 	}
 	
+	function hideContextProperty(context, name) {
+		_hideContextProperty(context, name);
+	}
 	
 	// Blacklist everything that does not make sense in C++ code.
 	// TODO(sompylasar): Add checks for these objects to the source code transform.
 	
 	// - everything in `global`.
 	for (var x in global) {
-		hideContextProperty(x);
+		hideContextProperty(context, x);
 	}
 	
 	// - the standard object types that are not in `global`.
@@ -43,7 +65,7 @@ function createContext() {
 		Int8Array, Uint16Array, Uint32Array, Uint8Array,
 		Error, EvalError, RangeError, ReferenceError, SyntaxError, TypeError, URIError
 	].forEach(function (x) {
-		hideContextProperty(x.name);
+		hideContextProperty(context, x.name);
 	});
 	
 	// - the Node.js-specific items.
@@ -53,7 +75,7 @@ function createContext() {
 		'global',
 		'JSON'
 	].forEach(function (x) {
-		hideContextProperty(x);
+		hideContextProperty(context, x);
 	});
 	
 	
@@ -103,18 +125,6 @@ function createContext() {
 	context.DemoObject = DemoObject;
 	
 	
-	// Freeze the context.
-	for (var x in context) {
-		if (context[x] !== undefined) {
-			Object.defineProperty(context, x, {
-				configurable: false,
-				enumerable: true,
-				writable: false
-			});
-		}
-	}
-	
-	
 	return context;
 }
 
@@ -129,24 +139,28 @@ function createContext() {
  * @param {string} options.when The generated name of the reference to `when`.
  * @return {string} The transformed source code.
  */
-function transformCode(code, options) {
+function transformCode(code, transformOptions, showTransformedCode) {
 	var recast = require('recast');
 	var n = recast.types.namedTypes;
 	var b = recast.types.builders;
-	
-	var retIdentifierName = '__ret' + Math.floor(1000 + Math.random() * 1000);
-	
-	var whenIdentifier = b.identifier(options.when);
-	var thenIdentifier = b.identifier('then');
-	var joinIdentifier = b.identifier('join');
-	var retIdentifier = b.identifier(retIdentifierName);
-	
 	
 	/**
 	 * Throws a `SyntaxError` for blacklisted expressions.
 	 */
 	function throwSyntaxError(node) {
 		throw new SyntaxError('Invalid expression: ' + recast.print(node).code);
+	}
+	
+	/**
+	 * Checks if the node is a function transformed from a C++ lambda.
+	 */
+	function isLambda(node) {
+		return (
+			(n.FunctionExpression.check(node) || n.FunctionDeclaration.check(node))
+			&& node.id && (
+				transformOptions.lambdas[node.id.name]
+			)
+		);
 	}
 	
 	/**
@@ -175,17 +189,21 @@ function transformCode(code, options) {
 			}
 		}
 		
-		// Blacklist function expressions that are not the lambdas converted to functions.
-		if (n.FunctionExpression.check(node) || n.FunctionDeclaration.check(node)) {
-			if (!(node.id && (
-				options
-				&& options.lambdas
-				&& options.lambdas.indexOf(node.id.name) >= 0
-			))) {
-				throwSyntaxError(node);
-			}
+		// Whitelist function expressions that are the lambdas converted to functions.
+		if (isLambda(node)) {
+			return;
 		}
 		
+		if (
+			n.VariableDeclaration.check(node)
+			&& node.declarations.length === 1
+			&& n.VariableDeclarator.check(node.declarations[0])
+			&& node.declarations[0].id && node.declarations[0].id.name === transformOptions.when
+		) {
+			return;
+		}
+		
+		// Blacklist other JavaScript-specific expressions.
 		if (
 			n.ArrayExpression.check(node)
 			|| n.ObjectExpression.check(node)
@@ -195,6 +213,8 @@ function transformCode(code, options) {
 			|| n.VariableDeclarator.check(node)
 			|| n.ForInStatement.check(node)
 			|| n.DebuggerStatement.check(node)
+			|| n.FunctionExpression.check(node)
+			|| n.FunctionDeclaration.check(node)
 		) {
 			throwSyntaxError(node);
 		}
@@ -212,195 +232,109 @@ function transformCode(code, options) {
 		}
 	}
 	
-	/**
-	 * Performs the following AST transform for a CallExpression:
-	 *     aaa(bbb, ccc) -> when.join(bbb, ccc).then(function (ret) { return aaa(ret[0], ret[1]); })
-	 */
-	function whenThenCallExpression(callExpression) {
-		checkBlacklist(callExpression);
-		checkBlacklist(callExpression.callee);
-		
-		// No need to wrap the empty list.
-		if (callExpression.arguments.length === 0) {
-			return callExpression;
-		}
-		
-		var allLiterals = true;
-		for (var ic = callExpression.arguments.length, i = 0; i < ic; ++i) {
-			checkBlacklist(callExpression.arguments[i]);
-			
-			allLiterals = allLiterals && n.Literal.check(callExpression.arguments[i]);
-		}
-		
-		// No need to wrap if all the arguments are literals.
-		if (allLiterals) {
-			return callExpression;
-		}
-		
-		var joinMember = b.memberExpression(
-			whenIdentifier,
-			joinIdentifier,
-			false
-		);
-		
-		var callWhen = b.callExpression(joinMember, callExpression.arguments.map(whenThen));
-		
-		var thenMember = b.memberExpression(
-			callWhen,
-			thenIdentifier,
-			false
-		);
-		
-		var retArguments = callExpression.arguments.map(function (arg, index) {
-			return b.memberExpression(
-				retIdentifier,
-				b.literal(index),
-				true
-			);
-		});
-		
-		var functionExpression = b.functionExpression(
-			null,
-			[ retIdentifier ],
-			b.blockStatement(
-				[
-					b.returnStatement(
-						b.callExpression(
-							callExpression.callee,
-							retArguments
-						)
-					)
-				]
-			)
-		);
-		
-		var callThen = b.callExpression(thenMember, [
-			functionExpression
-		]);
-		
-		return callThen;
-	}
+	// Parse the source code into the AST.
+	var ast = recast.parse(code);
 	
-	/**
-	 * Performs the following AST transform for a MemberExpression:
-	 *     aaa.bbb -> when(aaa).then(function (ret) { return ret.bbb; })
-	 */
-	function whenThenMemberExpression(memberExpression) {
-		checkBlacklist(memberExpression);
-		
-		var callWhen = b.callExpression(whenIdentifier, [
-			whenThen(memberExpression.object)
-		]);
-		
-		var thenMember = b.memberExpression(
-			callWhen,
-			thenIdentifier,
-			false
-		);
-		
-		var functionExpression = b.functionExpression(
-			null,
-			[ retIdentifier ],
-			b.blockStatement(
-				[
-					b.returnStatement(
-						b.memberExpression(
-							retIdentifier,
-							memberExpression.property,
-							memberExpression.computed
-						)
-					)
-				]
-			)
-		);
-		
-		var callThen = b.callExpression(thenMember, [
-			functionExpression
-		]);
-		
-		return callThen;
-	}
-	
-	/**
-	 * Wraps the given AST node in a `when(...).then(...)`.
-	 */
-	function whenThen(node) {
-		checkBlacklist(node);
-		
-		if (n.MemberExpression.check(node)) {
-			return whenThenMemberExpression(node);
-		}
-		else if (n.CallExpression.check(node)) {
-			return whenThenCallExpression(node);
-		}
-		else {
-			return node;
-		}
-	}
-	
-	
-	// The AST visitors.
-	var visitors = {
+	// Blacklist check.
+	recast.visit(ast, {
 		visitNode: function (path) {
 			checkBlacklist(path.value);
 			this.traverse(path);
-		},
-		visitCallExpression: function (path) {
-			path.replace(whenThen(path.value));
-			return false;
-		},
-		visitMemberExpression: function (path) {
-			path.replace(whenThen(path.value));
-			return false;
 		}
-	};
+	});
 	
+	// Transform to promise-aware code.
+	ast = require('./promise-transforms').transformAST(ast, transformOptions);
 	
-	// Parse and transform the AST, then compile back into the source code.
-	var ast = recast.parse(code);
-	recast.visit(ast, visitors);
-	return recast.print(ast).code;
+	// Compile back into the source code.
+	var code = recast.prettyPrint(ast).code;
+	
+	if (showTransformedCode) {
+		console.log(code.split('\n').map(function (line, index) {
+			return (('000' + (index + 1)).slice(-4) + ' | ' + line);
+		}).join('\n') + '\n');
+	}
+	
+	// Safety syntax check.
+	recast.parse(code);
+	
+	return code;
 }
 
 function evaluate(code, context, filename, callback, options) {
+	var contextifiedContext;
+	var result;
 	var timing;
+	
+	function dispose() {
+		try {
+			if (transformOptions) {
+				// Remove the references that were previously added to the context.
+				delete context[transformOptions.require];
+				delete context[transformOptions.console];
+				delete context[transformOptions.globals.SyntaxError];
+			}
+			if (contextifiedContext) {
+				contextifiedContext.dispose();
+				contextifiedContext = null;
+			}
+		}
+		catch (ex) {
+			console.error(ex);
+		}
+	}
+	
+	function finish(err, result, timing) {
+		if (timing && !timing.endTime) {
+			timing.end();
+		}
+		
+		dispose();
+		callback(err, result, timing);
+	}
+	
 	try {
 		var SPACE_RE = /\s+/g;
 		var TRIM_SPACE_RE = /(^\s+)|(\s+$)/g;
-	
-		// Matches "[ &anything ] ( Type123 name_123 ) {"
+		
+		// Matches "[ any, captured, vars ] ( Any typed_args ) {"
 		var CPP_LAMBDA_RE = /(\[([^\]]*?)\]\s*\(([^)]*?)\))\s*\{/g;
-	
+		
 		// Matches "name_123"
 		var CPP_IDENTIFIER_RE = /^([a-zA-Z_][a-zA-Z0-9_]*)\s*$/;
-	
+		
 		// Matches "const Type123 & name_123"
 		var CPP_ARG_RE = /^\s*(.*?)([a-zA-Z_][a-zA-Z0-9_]*)\s*$/;
-	
-		// Matches "function () {"
+		
+		// Matches "function (any, args) {"
 		var JS_ANONYMOUS_FUNCTION_RE = /\bfunction\b\s*\(([^)]*?)\)\s*\{/g;
-	
-	
+		
+		
 		// Blacklist anonymous top-level functions (the parser throws 'Unexpected (' on them).
 		var anonymousFunctionMatch = JS_ANONYMOUS_FUNCTION_RE.exec(code);
 		if (anonymousFunctionMatch) {
 			throw new SyntaxError('Invalid expression: ' + anonymousFunctionMatch[0]);
 		}
-	
-		var syntaxErrorIdentifierName = '__syntaxError' + Math.floor(1000 + Math.random() * 1000);
-		context[syntaxErrorIdentifierName] = SyntaxError;
-	
-		// The array of converted lambda names that will be whitelisted in the parser.
-		var lambdas = [];
-	
+		
+		
+		var transformOptions = transforms.createOptions();
+		
+		var globals = transformOptions.globals = transformOptions.globals || {};
+		
+		globals["SyntaxError"] = transforms.makeRandomIdentifierName('__SyntaxError');
+		
+		
+		// The set of converted lambda names that will be whitelisted in the parser.
+		var lambdas = transformOptions.lambdas = transformOptions.lambdas || {};
+		
 		// Convert C++ lambda syntax to JS.
 		code = code.replace(CPP_LAMBDA_RE, function (m, header, captures, args) {
 			// Generate a unique name for this lambda.
-			var lambdaIdentifierName = '__lambda' + Math.floor(1000 + Math.random() * 1000);
-		
+			var lambdaIdentifierName = transforms.makeRandomIdentifierName('__lambda');
+			
 			// Remember the lambda name for whitelisting.
-			lambdas.push(lambdaIdentifierName);
-		
+			lambdas[lambdaIdentifierName] = lambdaIdentifierName;
+			
 			// Collect the captured names to reference them later.
 			var captureNames = captures.split(/,\s*/).map(function (capture) {
 				var captureName = capture.replace(SPACE_RE).replace(/[^a-zA-Z0-9_]+/g, '');
@@ -408,84 +342,92 @@ function evaluate(code, context, filename, callback, options) {
 			}).filter(function (captureName) {
 				return !!captureName;
 			});
-		
+			
 			// Collect expressions that check the arguments inside the function.
 			var checkArgs = [];
-		
+			
 			// Filter out argument types and modifiers, keep only names.
 			var argNames = args.split(/,\s*/).map(function (arg) {
 				var argParts = CPP_ARG_RE.exec(arg);
 				var argType = (argParts[1] || '').replace(TRIM_SPACE_RE, '');
 				var argName = (argParts[2] || '').replace(TRIM_SPACE_RE, '');
-			
+				
 				// Whitelist only arguments without modifiers.
 				if (!CPP_IDENTIFIER_RE.test(argType) || !CPP_IDENTIFIER_RE.test(argName)) {
 					throw new SyntaxError('Invalid expression: ' + m);
 				}
-			
+				
 				if (context[argType] === undefined) {
 					throw new SyntaxError('Unknown type: ' + argType);
 				}
-			
+				
 				checkArgs.push(
 					'\tif (' + argName + ' === undefined) {\n' +
-						'\t\tthrow ' + syntaxErrorIdentifierName + '(\'Argument "' + argName + '" missing from the call to ' + header.replace('\'', '\\\'') + '.\');\n' +
+						'\t\tthrow ' + transformOptions.globals.SyntaxError +
+							'(\'Argument "' + argName + '" missing from the call to ' + header.replace('\'', '\\\'') + '.\');\n' +
 					'\t}\n'
 				);
-			
+				
 				return argName;
 			});
-		
+			
 			return (
 				// Reference the captured names to test if they are defined.
 				(captureNames.length ? ';(' + captureNames.join(');(') + ');\n' : '') +
-			
+				
 				// Transform the lambda into a JS function.
 				// Assignment is used to convert to the FunctionExpression.
 				// We cannot use `(` because the position of the closing `}` is not known.
 				lambdaIdentifierName + ' = function ' + lambdaIdentifierName + '(' + argNames + ') {\n' +
-			
+				
 				// Add arguments check.
 				checkArgs.join('')
 			);
 		});
 		
-		// Put a reference to `when` into the context.
-		// We generate random identifier to prevent exploiting it from the provided code.
-		var whenIdentifierName = '__when' + Math.floor(1000 + Math.random() * 1000);
-		context[whenIdentifierName] = when;
+		_hideContextProperty(context, transformOptions.require, require);
+		_hideContextProperty(context, transformOptions.console, console);
+		_hideContextProperty(context, transformOptions.globals.SyntaxError, SyntaxError);
+		
+		Object.keys(context).forEach(function (x) {
+			if (context[x] !== undefined) {
+				globals[x] = x;
+			}
+		});
 		
 		// Convert the code to promise-based.
 		// `when` is referenced via the passed identifier.
-		code = transformCode(code, {
-			when: whenIdentifierName,
-			lambdas: lambdas
-		});
+		code = transformCode(code, transformOptions,
+			options && options.showTransformedCode
+		);
 		
 		if (options && options.showContext) {
 			console.log(require('util').inspect(context));
 		}
 		
-		if (options && options.showTransformedCode) {
-			console.log(code.split('\n').map(function (line, index) {
-				return ((index + 1) + ' | ' + line);
-			}).join('\n') + '\n');
+		if (USE_CONTEXTIFY) {
+			// Start the timing measurement.
+			timing = require('./bricks-timing')();
+			
+			// Execute the script.
+			result = context.run(code);
 		}
-		
-		// Compile the script from the code.
-		var script = vm.createScript(code, {
-			filename: filename,
-			displayErrors: false
-		});
-		
-		// Start the timing measurement.
-		timing = require('./bricks-timing')();
-		
-		// Execute the script.
-		var result = script.runInContext(context, {
-			displayErrors: false,
-			timeout: 10000
-		});
+		else {
+			// Compile the script from the code.
+			var script = vm.createScript(code, {
+				filename: filename,
+				displayErrors: false
+			});
+			
+			// Start the timing measurement.
+			timing = require('./bricks-timing')();
+			
+			// Execute the script.
+			result = script.runInContext(context, {
+				displayErrors: false,
+				timeout: 10000
+			});
+		}
 		
 		// Wait for the result to resolve.
 		when(result).done(function (actualResult) {
@@ -495,27 +437,17 @@ function evaluate(code, context, filename, callback, options) {
 			// TODO(sompylasar): Think up something for the APIs that return void.
 			if (typeof actualResult === 'undefined') {
 				var err = new Error('The result is `undefined`.');
-				callback(err, undefined, timing);
+				finish(err, undefined, timing);
 				return;
 			}
 			
-			callback(null, actualResult, timing);
+			finish(null, actualResult, timing);
 		}, function (err) {
-			timing.end();
-			
-			callback(err, undefined, timing);
+			finish(err, undefined, timing);
 		});
 	}
 	catch (ex) {
-		if (timing) {
-			timing.end();
-		}
-		
-		callback(ex, undefined, timing);
-	}
-	finally {
-		// Remove the reference to `when` that was previously added to the context.
-		delete context[whenIdentifierName];
+		finish(ex, undefined, timing);
 	}
 }
 

--- a/lib/bricks-evaluate.js
+++ b/lib/bricks-evaluate.js
@@ -75,6 +75,8 @@ function createContext() {
 		this.demo_map = {
 			"key": "value"
 		};
+		
+		require('./bricks-json').Serializable.call(this);
 	}
 	
 	/**

--- a/lib/bricks-json.js
+++ b/lib/bricks-json.js
@@ -4,8 +4,32 @@ var inspect = require('util').inspect;
 
 var cppArguments = require('./cpp-arguments');
 
+var JavaScriptJSON = global.JSON;
 
-exports.JSON = function () {
+
+function Serializable() {
+	var _this = this;
+	
+	Object.defineProperties(_this, {
+		serialize: {
+			configurable: false,
+			enumerable: false,
+			writable: false,
+			value: function (ar) {
+				Object.keys(_this).forEach(function (key) {
+					if (typeof _this[key] === 'function') {
+						return;
+					}
+					
+					ar[key] = _this[key];
+				});
+			}
+		}
+	});
+}
+
+
+function JSON() {
 	return cppArguments.assert('JSON', [
 		[
 			cppArguments.assertion('object', 'T&&', 'object'),
@@ -14,42 +38,40 @@ exports.JSON = function () {
 				if (typeof object.serialize !== 'function') {
 					throw new Error('JSON: Object is not serializable: ' + inspect(object));
 				}
-		
+				
+				var ar = {};
+				
 				if (typeof name === 'string') {
-					object = Object.create({
-						serialize: function () {
-							return object;
-						}
-					});
-			
-					object[name] = ret;
+					ar[name] = {};
+					object.serialize(ar[name]);
 				}
-		
-				return JSON.stringify(object.serialize());
+				else {
+					object.serialize(ar);
+				}
+				
+				return JavaScriptJSON.stringify(ar);
 			}
 		]
 	], arguments);
-};
+}
 
-exports.ParseJSON = function () {
+
+function ParseJSON() {
 	return cppArguments.assert('ParseJSON', [
 		[
 			cppArguments.assertion('string', 'const std::string&', 'str'),
 			function (str) {
-				var parsed = JSON.parse(str);
+				var object = JavaScriptJSON.parse(str);
 				
-				var object = Object.create({
-					serialize: function () {
-						return object;
-					}
-				});
-				
-				for (var x in parsed) {
-					object[x] = parsed[x];
-				}
+				Serializable.call(object);
 				
 				return object;
 			}
 		]
 	], arguments);
-};
+}
+
+
+exports.Serializable = Serializable;
+exports.JSON = JSON;
+exports.ParseJSON = ParseJSON;

--- a/lib/bricks-json.js
+++ b/lib/bricks-json.js
@@ -54,16 +54,13 @@ function JSON() {
 					throw new Error('JSON: Object is not serializable: ' + inspect(object));
 				}
 				
-				var ar = {};
+				if (typeof name !== 'string') {
+					name = "value0";
+				}
 				
-				if (typeof name === 'string') {
-					ar[name] = {};
-					object.serialize(ar[name]);
-				}
-				else {
-					ar["value0"] = {};
-					object.serialize(ar["value0"]);
-				}
+				var ar = {};
+				ar[name] = {};
+				object.serialize(ar[name]);
 				
 				return JavaScriptJSON.stringify(ar);
 			}

--- a/lib/bricks-json.js
+++ b/lib/bricks-json.js
@@ -1,21 +1,55 @@
 'use strict';
 
-var when = require('when');
+var inspect = require('util').inspect;
+
+var cppArguments = require('./cpp-arguments');
 
 
-exports.JSON = function (object, name) {
-	return when(object).then(function (ret) {
-		var object = ret;
-		if (typeof name === 'string') {
-			object = {};
-			object[name] = ret;
-		}
-		return JSON.stringify(object);
-	});
+exports.JSON = function () {
+	return cppArguments.assert('JSON', [
+		[
+			cppArguments.assertion('object', 'T&&', 'object'),
+			cppArguments.assertion('string', 'const std::string&', 'name', cppArguments.ASSERTION_MODE_OPTIONAL),
+			function (object, name) {
+				if (typeof object.serialize !== 'function') {
+					throw new Error('JSON: Object is not serializable: ' + inspect(object));
+				}
+		
+				if (typeof name === 'string') {
+					object = Object.create({
+						serialize: function () {
+							return object;
+						}
+					});
+			
+					object[name] = ret;
+				}
+		
+				return JSON.stringify(object.serialize());
+			}
+		]
+	], arguments);
 };
 
-exports.ParseJSON = function (arg) {
-	return when(arg).then(function (ret) {
-		return JSON.parse(ret);
-	});
+exports.ParseJSON = function () {
+	return cppArguments.assert('ParseJSON', [
+		[
+			cppArguments.assertion('string', 'const std::string&', 'str'),
+			function (str) {
+				var parsed = JSON.parse(str);
+				
+				var object = Object.create({
+					serialize: function () {
+						return object;
+					}
+				});
+				
+				for (var x in parsed) {
+					object[x] = parsed[x];
+				}
+				
+				return object;
+			}
+		]
+	], arguments);
 };

--- a/lib/bricks-json.js
+++ b/lib/bricks-json.js
@@ -8,17 +8,32 @@ var JavaScriptJSON = global.JSON;
 
 
 function Serializable() {
-	var _this = this;
-	
-	Object.defineProperties(_this, {
+	Object.defineProperties(this, {
 		serialize: {
 			configurable: false,
 			enumerable: false,
 			writable: false,
-			value: function (ar) {
+			value: this.serialize || function (ar) {
+				var _this = this;
+				
 				Object.keys(_this).forEach(function (key) {
 					if (typeof _this[key] === 'function') {
+						// Ignore functions.
 						return;
+					}
+					
+					if (typeof _this[key] === 'object') {
+						if (Array.isArray(_this[key])) {
+							ar[key] = [].slice.call(_this[key]);
+						}
+						else if (_this[key] && typeof _this[key].serialize === 'function') {
+							ar[key] = {};
+							_this[key].serialize(ar[key]);
+						}
+						else {
+							// Ignore objects if they are not serializable.
+							return;
+						}
 					}
 					
 					ar[key] = _this[key];
@@ -46,7 +61,8 @@ function JSON() {
 					object.serialize(ar[name]);
 				}
 				else {
-					object.serialize(ar);
+					ar["value0"] = {};
+					object.serialize(ar["value0"]);
 				}
 				
 				return JavaScriptJSON.stringify(ar);

--- a/lib/bricks-net-api.js
+++ b/lib/bricks-net-api.js
@@ -57,7 +57,7 @@ function makeInspectDocumentationMethod(name, docuFn) {
 			(docuFn
 				? docuFn.call(this, name).split('\n').join('\n// ')
 				: ''
-			)
+			) + '.'
 		);
 	};
 }

--- a/lib/bricks-net-http-impl.js
+++ b/lib/bricks-net-http-impl.js
@@ -129,7 +129,7 @@ function TemplatedHTTPRequestData(connection) {
 		}
 		
 		
-		var UINT_MAX = 4294967295;
+		var UINT_MAX = 0xffffffff;
 		
 		var intial_buffer_size = 1600;
 		var buffer_growth_k = 1.95;

--- a/lib/bricks-net-http-impl.js
+++ b/lib/bricks-net-http-impl.js
@@ -648,6 +648,8 @@ function HTTPServerConnection(connection) {
 			configurable: true,
 			enumerable: false,
 			value: function () {
+				_this._DEBUG_LOG(_this + '#destroy.');
+				
 				return when.resolve()
 					.then(function () {
 						if (_this.chunked_response_sender_) {

--- a/lib/bricks-net-http-mime_type.js
+++ b/lib/bricks-net-http-mime_type.js
@@ -21,7 +21,7 @@ var file_extension_to_mime_type_map = {
 exports.GetFileMimeType = function () {
 	return cppArguments.assert('GetFileMimeType', [
 		[
-			cppArguments.assertion('string', 'const std::string&', 'pfile_nameath'),
+			cppArguments.assertion('string', 'const std::string&', 'file_name'),
 			cppArguments.assertion('string', 'const std::string&', 'default_type', cppArguments.ASSERTION_MODE_OPTIONAL),
 			function (file_name, default_type) {
 				if (typeof default_type === 'undefined') {

--- a/lib/bricks-net-http-server.js
+++ b/lib/bricks-net-http-server.js
@@ -288,7 +288,9 @@ exports.HandlerDoesNotExistException = HandlerDoesNotExistException;
 exports.ConnectionClose = ConnectionClose;
 exports.ConnectionKeepAlive = ConnectionKeepAlive;
 
-// Export to add the documentation in `bricks-net-api`.
+// The user code should not create instances of the following classes directly but
+// the user may want to evaluate the classes in the REPL to get the documentation.
+// Export them so the `bricks-net-api` module can add the `inspect` documentation.
 exports.HTTPServer = HTTPServer;
 exports.Request = Request;
 

--- a/lib/bricks-net-http-server.js
+++ b/lib/bricks-net-http-server.js
@@ -267,11 +267,12 @@ HTTPServer.prototype.ServeStaticFilesFrom = function () {
 	], arguments, this);
 };
 HTTPServer.prototype.ResetAllHandlers = function () {
-	for (var ic = this.handlers_paths_.length, i = 0; i < ic; ++i) {
-		this.UnRegister(this.handlers_paths_[i]);
-		--i;
-		--ic;
+	var _this = this;
+	
+	for (var ic = _this.handlers_paths_.length, i = 0; i < ic; ++i) {
+		delete _this.handlers_[_this.handlers_paths_[i]];
 	}
+	_this.handlers_paths_.length = 0;
 };
 HTTPServer.prototype.HandlersCount = function () {
 	return this.handlers_paths_.length;

--- a/lib/bricks-net-http-server.js
+++ b/lib/bricks-net-http-server.js
@@ -74,12 +74,16 @@ function Request(connection) {
 			value: function () {
 				return 'Request(' + connection + ')';
 			}
+		},
+		SendChunkedResponse: {
+			configurable: false,
+			enumerable: false,
+			writable: false,
+			value: function () {
+				return _this.connection.SendChunkedHTTPResponse();
+			}
 		}
 	});
-	
-	_this.SendChunkedResponse = function () {
-		return _this.connection.SendChunkedHTTPResponse();
-	};
 	
 	_this.connection = connection;
 	var http_data = _this.http_data = connection.HTTPRequest();

--- a/lib/bricks-net-http-server.js
+++ b/lib/bricks-net-http-server.js
@@ -163,13 +163,24 @@ function HTTPServer(port) {
 					_this._DEBUG_LOG(_this + ': ' + connection + ' ' + path + ' handler not found.');
 					return connection.SendHTTPResponse(DefaultFourOhFourMessage(), HTTPResponseCode.NotFound, "text/html");
 				}
-			}).then(function () {
+			})
+			.then(function () {
 				_this._DEBUG_LOG(_this + ': ' + connection + ' served successfully.');
 			}, function (err) {
 				_this._DEBUG_LOG(_this + ': ' + connection + ' serving error:', err);
-			}).done(function () {
+				
+				process.stderr.write(_this + ': ' + connection + ' serving error: ' +
+					(process.env.NODE_ENV === 'development' ? err.stack : err) + '\n\n');
+			})
+			.then(function () {
 				// Call the destructor-like method when the handler has finished.
-				connection.destroy();
+				return connection.destroy();
+			})
+			.then(undefined, function (err) {
+				_this._DEBUG_LOG(_this + ': ' + connection + ' destroy error:', err);
+				
+				process.stderr.write(_this + ': ' + connection + ' destroy error: ' +
+					(process.env.NODE_ENV === 'development' ? err.stack : err) + '\n\n');
 			});
 			
 			_accept();

--- a/lib/bricks-net-url.js
+++ b/lib/bricks-net-url.js
@@ -245,7 +245,20 @@ function URL() {
 	function QueryParameters(parameters_vector) {
 		var _this = this;
 		
-		_this.parameters_ = {};
+		Object.defineProperties(_this, {
+			parameters_vector_: {
+				configurable: false,
+				enumerable: false,
+				writable: false,
+				value: parameters_vector
+			},
+			parameters_: {
+				configurable: false,
+				enumerable: false,
+				writable: false,
+				value: {}
+			}
+		});
 		
 		parameters_vector.forEach(function (param) {
 			_this.parameters_[param.first] = param.second;
@@ -331,12 +344,24 @@ function URL() {
 	], arguments);
 	
 	
-	this.ComposeParameters = function () {
-		return URLParametersExtractor_ComposeParameters();
-	};
-	this.ComposeURL = function () {
-		return URLWithoutParametersParser_ComposeURL() + URLParametersExtractor_ComposeParameters();
-	};
+	Object.defineProperties(_this, {
+		ComposeParameters: {
+			configurable: false,
+			enumerable: false,
+			writable: false,
+			value: function () {
+				return URLParametersExtractor_ComposeParameters();
+			}
+		},
+		ComposeURL: {
+			configurable: false,
+			enumerable: false,
+			writable: false,
+			value: function () {
+				return URLWithoutParametersParser_ComposeURL() + URLParametersExtractor_ComposeParameters();
+			}
+		}
+	});
 }
 
 exports.URL = URL;

--- a/lib/cpp-arguments.js
+++ b/lib/cpp-arguments.js
@@ -135,7 +135,13 @@ var baseAssertions = {
 	},
 	object: {
 		check: function (value) {
+			return (typeof value === 'object' && value !== null);
+		}
+	},
+	plainObject: {
+		check: function (value) {
 			return (typeof value === 'object'
+				&& value !== null
 				&& (
 					value === Object_prototype
 					|| Object_getPrototypeOf(value) === Object_prototype

--- a/lib/promise-transforms.js
+++ b/lib/promise-transforms.js
@@ -1,0 +1,628 @@
+'use strict';
+
+var inherits = require('util').inherits;
+var inspect = require('util').inspect;
+var assert = require('assert');
+
+var recast = require('recast');
+var types = recast.types;
+var n = types.namedTypes;
+var b = types.builders;
+
+var extend = require('./extend');
+
+
+function makeRandomIdentifierName(prefix) {
+	var identifierName = (prefix + Math.floor(1000 + Math.random() * 1000));
+	
+	return identifierName;
+}
+
+var _DEBUG_LOG_TRANSFORM;
+/* istanbul ignore next: debug method */
+_DEBUG_LOG_TRANSFORM = function (where, sourceNode, resultNode) {
+	if (resultNode === sourceNode) {
+		console.log('\n\n' +
+			'## ' + where + '\n' +
+			'## Source:\n' + recast.prettyPrint(sourceNode).code + '\n' + inspect(sourceNode) + '\n\n' +
+			'## Result: (unchanged)' + '\n\n'
+		);
+		return;
+	}
+	
+	console.log('\n\n' +
+		'## ' + where + '\n' +
+		'## Source:\n' + recast.prettyPrint(sourceNode).code + '\n' + inspect(sourceNode) + '\n\n' +
+		'## Result:\n' + recast.prettyPrint(resultNode).code + '\n' + inspect(resultNode) + '\n\n'
+	);
+};
+/* istanbul ignore next: debug method */
+_DEBUG_LOG_TRANSFORM = function () {};
+
+
+function Transformer(options) {
+	types.PathVisitor.call(this);
+	
+	var _this = this;
+	
+	_this.options = options;
+	
+	// Keep track of all the generated nodes.
+	_this._generated = [];
+	
+	_this.requireIdentifier = _this.makeNode('identifier', _this.options.require);
+	_this.consoleIdentifier = _this.makeNode('identifier', _this.options.console);
+	_this.logIdentifier = _this.makeNode('identifier', 'log');
+	_this.thenIdentifier = _this.makeNode('identifier', 'then');
+	_this.joinIdentifier = _this.makeNode('identifier', 'join');
+	_this.retIdentifier = _this.makeNode('identifier', _this.options.ret);
+	_this.argsIdentifier = _this.makeNode('identifier', 'args');
+	_this.bindIdenifier = _this.makeNode('identifier', 'bind');
+	
+	_this.whenReference = _this.makeRequire('when');
+	_this.whenSequenceReference = _this.makeRequire('when/sequence');
+	
+	_this.consoleLogMember = _this.makeNode('memberExpression',
+		_this.consoleIdentifier,
+		_this.logIdentifier,
+		false
+	);
+	
+	_this.whenJoinMember = _this.makeNode('memberExpression',
+		_this.whenReference,
+		_this.joinIdentifier,
+		false
+	);
+}
+inherits(Transformer, types.PathVisitor);
+extend(Transformer.prototype, {
+	isGlobalIdentifier: function (node) {
+		var _this = this;
+		return (
+			n.Identifier.check(node)
+			&& Object.keys(_this.options.globals).some(function (x) {
+				return (node.name === _this.options.globals[x]);
+			})
+		);
+	},
+	
+	isLambdaIdentifier: function (node) {
+		var _this = this;
+		return (
+			n.Identifier.check(node)
+			&& Object.keys(_this.options.lambdas).some(function (x) {
+				return (node.name === _this.options.lambdas[x]);
+			})
+		);
+	},
+	
+	isLambdaArgumentCheck: function (path) {
+		var _this = this;
+		var node = path.value;
+		
+		var ifStatement = node;
+		var ifStatementBlock = (
+			n.IfStatement.check(ifStatement) && ifStatement.consequent
+		);
+		var ifStatementBlockBody = (
+			ifStatementBlock && ifStatementBlock.body
+		);
+		var throwStatement = (
+			ifStatementBlockBody && ifStatementBlockBody[0]
+		);
+		var syntaxErrorCall = (
+			n.ThrowStatement.check(throwStatement) && throwStatement.argument
+		);
+		var syntaxErrorIdentifier = (
+			n.CallExpression.check(syntaxErrorCall) && syntaxErrorCall.callee
+		);
+		
+		var ret = (
+			syntaxErrorIdentifier
+			&& n.Identifier.check(syntaxErrorIdentifier)
+			&& syntaxErrorIdentifier.name === _this.options.globals.SyntaxError
+		);
+		
+		return ret;
+	},
+	
+	isRootExpression: function (path) {
+		return (
+			path.parentPath
+			&& n.ExpressionStatement.check(path.parentPath.value)
+			&& path.parentPath.parentPath
+			&& ({}.toString.call(path.parentPath.parentPath.value) === '[object Array]')
+			&& path.parentPath.parentPath.parentPath
+			&& n.Program.check(path.parentPath.parentPath.parentPath.value)
+		);
+	},
+	
+	isGeneratedNode: function (node) {
+		var _this = this;
+		
+		return (_this._generated.indexOf(node) >= 0);
+	},
+	
+	makeNode: function () {
+		var _this = this;
+		
+		var args = [].slice.call(arguments);
+		var type = args.shift();
+		
+		var node = b[type].apply(b, args);
+		
+		_this._generated.push(node);
+		
+		return node;
+	},
+	
+	makeRequire: function (moduleName) {
+		var _this = this;
+		
+		return _this.makeNode('callExpression',
+			_this.requireIdentifier,
+			[ _this.makeNode('literal', moduleName) ]
+		);
+	},
+	
+	makeLogCall: function (node) {
+		var _this = this;
+		
+		return _this.makeNode('emptyStatement');
+		/*
+		return _this.makeNode('expressionStatement', _this.makeNode('callExpression', 
+			_this.consoleLogMember,
+			[ node ]
+		) );
+		*/
+	},
+	
+	getReplacementForIdentifier: function (path) {
+		var _this = this;
+		var node = path.value;
+		
+		if (_this.isGeneratedNode(node)) {
+			_DEBUG_LOG_TRANSFORM('Identifier isGeneratedNode', node, node);
+			return node;
+		}
+		
+		if (
+			_this.isGlobalIdentifier(node)
+			|| _this.isLambdaIdentifier(node)
+		) {
+			_DEBUG_LOG_TRANSFORM('Identifier', node, node);
+			return node;
+		}
+		
+		// Get the name of the function that contains the node as an argument.
+		// If it's a lambda, do not wrap the identifier with `when(...)`.
+		if (
+			path.parentPath
+			&& ({}.toString.call(path.parentPath.value) === '[object Array]')
+			&& path.parentPath.parentPath
+			&& n.FunctionExpression.check(path.parentPath.parentPath.value)
+			&& _this.isLambdaIdentifier(path.parentPath.parentPath.value.id)
+		) {
+			_DEBUG_LOG_TRANSFORM('Identifier', node, node);
+			return node;
+		}
+		
+		// when(<identifier>)
+		var whenCall = _this.makeNode('callExpression',
+			_this.whenReference,
+			[ node ]
+		);
+		
+		_DEBUG_LOG_TRANSFORM('Identifier', node, whenCall);
+		return whenCall;
+	},
+	
+	getReplacementForMemberExpression: function (path) {
+		var _this = this;
+		var node = path.value;
+		
+		if (_this.isGeneratedNode(node)) {
+			_DEBUG_LOG_TRANSFORM('MemberExpression isGeneratedNode', node, node);
+			return node;
+		}
+		
+		if (_this.isGlobalIdentifier(node.object)) {
+			_DEBUG_LOG_TRANSFORM('MemberExpression isGlobalIdentifier', node, node);
+			return node;
+		}
+		
+		if (_this.isLambdaIdentifier(node.object)) {
+			_DEBUG_LOG_TRANSFORM('MemberExpression isLambdaIdentifier', node, node);
+			return node;
+		}
+		
+		// <object>.then
+		var thenMember = _this.makeNode('memberExpression',
+			_this.getReplacementFor(path.get('object')),
+			_this.thenIdentifier,
+			false
+		);
+		
+		// ret.<property> or ret[<property>]
+		var retMember = _this.makeNode('memberExpression',
+			_this.retIdentifier,
+			node.property,
+			node.computed
+		);
+		
+		var retReturn;
+		
+		// If this MemberExpression is a callee inside a CallExpression,
+		// bind the original context.
+		if (
+			path.parentPath
+			&& n.CallExpression.check(path.parentPath.value)
+			&& path.parentPath.value.callee === node
+		) {
+			var bindMember = _this.makeNode('memberExpression',
+				retMember,
+				_this.bindIdenifier,
+				false
+			);
+			
+			// <retMember>.bind(ret)
+			var bindCall = _this.makeNode('callExpression',
+				bindMember,
+				[ _this.retIdentifier ]
+			);
+			
+			// return <isFunctionConditional>;
+			retReturn = _this.makeNode('returnStatement',
+				bindCall
+			);
+		}
+		else {
+			// return <isFunctionConditional>;
+			retReturn = _this.makeNode('returnStatement',
+				retMember
+			);
+		}
+		
+		// function (ret) { <retReturn> }
+		var thenFunction = _this.makeNode('functionExpression',
+			null,
+			[ _this.retIdentifier ],
+			_this.makeNode('blockStatement', [
+				_this.makeLogCall(_this.whenReference),
+				retReturn
+			])
+		);
+		
+		// <object>.then(<thenFunction>)
+		var thenCall = _this.makeNode('callExpression',
+			thenMember,
+			[ thenFunction ]
+		);
+		
+		_DEBUG_LOG_TRANSFORM('MemberExpression', node, thenCall);
+		return thenCall;
+	},
+	
+	getReplacementForCallExpression: function (path) {
+		var _this = this;
+		var node = path.value;
+		
+		if (_this.isGeneratedNode(node)) {
+			_DEBUG_LOG_TRANSFORM('CallExpression isGeneratedNode', node, node);
+			return node;
+		}
+		
+		// No need to wrap if all the arguments are literals or there are no arguments.
+		var allLiterals = true;
+		var args = node.arguments;
+		for (var ic = args.length, i = 0; i < ic; ++i) {
+			allLiterals = allLiterals && (
+				n.Literal.check(args[i])
+				|| (n.AssignmentExpression.check(args[i])
+					&& n.Identifier.check(args[i].left)
+					&& _this.isLambdaIdentifier(args[i].left)
+				)
+			);
+		}
+		
+		var joinArguments;
+		var retArguments;
+		if (allLiterals) {
+			// Nothing to join, will generate a direct call.
+			joinArguments = [];
+			
+			// <"x">, <"y">
+			retArguments = args;
+		}
+		else {
+			// <x>, <y>
+			joinArguments = args.map(function (arg, index) {
+				var argPath = path.get('arguments', index);
+				
+				if (
+					n.CallExpression.check(argPath.value)
+					&& n.Identifier.check(argPath.value.callee)
+					&& _this.isGlobalIdentifier(argPath.value.callee)
+				) {
+					_this.traverse(argPath.parentPath);
+					return argPath.value;
+				}
+				
+				return _this.getReplacementFor(argPath);
+			});
+			
+			// args[0], args[1]
+			retArguments = args.map(function (arg, index) {
+				return _this.makeNode('memberExpression',
+					_this.argsIdentifier,
+					_this.makeNode('literal', index),
+					true
+				);
+			});
+		}
+		
+		var calleeThenable = _this.getReplacementFor(path.get('callee'));
+		var callInsideJoinThenFunction;
+		
+		if (calleeThenable === node.callee) {
+			callInsideJoinThenFunction = _this.makeNode('callExpression',
+				node.callee,
+				retArguments
+			);
+		}
+		else {
+			// ret(<retArguments>)
+			var retCall = _this.makeNode('callExpression',
+				_this.retIdentifier,
+				retArguments
+			);
+			
+			// return <retCall>;
+			var retReturn = _this.makeNode('returnStatement',
+				retCall
+			);
+			
+			// function (ret) { <retReturn>; }
+			var retThenFunction = _this.makeNode('functionExpression',
+				null,
+				[ _this.retIdentifier ],
+				_this.makeNode('blockStatement', [
+					_this.makeLogCall(_this.whenReference),
+					retReturn
+				])
+			);
+			
+			// <calleeThenable>.then
+			var retThenMember = _this.makeNode('memberExpression',
+				calleeThenable,
+				_this.thenIdentifier,
+				false
+			);
+			
+			// <calleeThenable>.then(<retThenFunction>)
+			var retThenCall = _this.makeNode('callExpression',
+				retThenMember,
+				[ retThenFunction ]
+			);
+			
+			callInsideJoinThenFunction = retThenCall;
+		}
+		
+		if (allLiterals) {
+			if (_this.isRootExpression(path)) {
+				_DEBUG_LOG_TRANSFORM('CallExpression is allLiterals at root', node, callInsideJoinThenFunction);
+				return callInsideJoinThenFunction;
+			}
+			
+			if (calleeThenable !== node.callee) {
+				_DEBUG_LOG_TRANSFORM('CallExpression is allLiterals and converted to thenable', node, callInsideJoinThenFunction);
+				return callInsideJoinThenFunction;
+			}
+			
+			var whenCall = _this.makeNode('callExpression',
+				_this.whenReference,
+				[ callInsideJoinThenFunction ]
+			);
+			
+			_DEBUG_LOG_TRANSFORM('CallExpression is allLiterals', node, whenCall);
+			return whenCall;
+		}
+		else {
+			// return <actualCall>;
+			var joinThenReturn = _this.makeNode('returnStatement',
+				callInsideJoinThenFunction
+			);
+			
+			// function (args) { <joinThenReturn> }
+			var joinThenFunction = _this.makeNode('functionExpression',
+				null,
+				[ _this.argsIdentifier ],
+				_this.makeNode('blockStatement', [
+					_this.makeLogCall(_this.whenReference),
+					joinThenReturn
+				])
+			);
+			
+			// when.join(<joinArguments>);
+			var joinCall = _this.makeNode('callExpression',
+				_this.whenJoinMember,
+				joinArguments
+			);
+			
+			// <joinCall>.then
+			var joinThenMember = _this.makeNode('memberExpression',
+				joinCall,
+				_this.thenIdentifier,
+				false
+			);
+			
+			// <joinThenMember>(<joinThenFunction>);
+			var joinThenCall = _this.makeNode('callExpression',
+				joinThenMember,
+				[ joinThenFunction ]
+			);
+			
+			_DEBUG_LOG_TRANSFORM('CallExpression', node, joinThenCall);
+			return joinThenCall;
+		}
+	},
+	
+	getReplacementForFunctionExpression: function (path) {
+		var _this = this;
+		var node = path.value;
+		
+		if (_this.isGeneratedNode(node)) {
+			_DEBUG_LOG_TRANSFORM('FunctionExpression isGeneratedNode', node, node);
+			return node;
+		}
+		
+		var statements = (
+			n.BlockStatement.check(node.body)
+				? node.body.body
+				: [ _this.makeNode('expressionStatement', node.body) ]
+		);
+		
+		var arrayOfTasks = _this.makeNode('arrayExpression',
+			statements.map(function (statement) {
+				// Add `return` to thenable statements.
+				if (n.ExpressionStatement.check(statement)) {
+					statement = _this.makeNode('returnStatement',
+						statement.expression
+					);
+				}
+				
+				return _this.makeNode('functionExpression',
+					null,
+					[],
+					_this.makeNode('blockStatement',
+						[ statement ]
+					)
+				);
+			})
+		);
+		
+		var whenSequenceCall = _this.makeNode('callExpression',
+			_this.whenSequenceReference,
+			[ arrayOfTasks ]
+		);
+		
+		var returnStatement = _this.makeNode('returnStatement',
+			whenSequenceCall
+		);
+		
+		var functionBlockStatement = _this.makeNode('blockStatement',
+			[ returnStatement ]
+		);
+		
+		var functionExpression = _this.makeNode('functionExpression',
+			node.id,
+			node.params,
+			functionBlockStatement
+		);
+		
+		_DEBUG_LOG_TRANSFORM('FunctionExpression', node, functionExpression);
+		
+		return functionExpression;
+	},
+	
+	getReplacementFor: function (path) {
+		var _this = this;
+		var node = path.value;
+		
+		if (n.Identifier.check(node)) {
+			return _this.getReplacementForIdentifier(path);
+		}
+		else if (n.MemberExpression.check(node)) {
+			return _this.getReplacementForMemberExpression(path);
+		}
+		else if (n.CallExpression.check(node)) {
+			return _this.getReplacementForCallExpression(path);
+		}
+		else if (n.FunctionExpression.check(node)) {
+			return _this.getReplacementForFunctionExpression(path);
+		}
+		
+		return node;
+	},
+	
+	visitIdentifier: function (path) {
+		var _this = this;
+		
+		path.replace(_this.getReplacementForIdentifier(path));
+		
+		return false;
+	},
+	
+	visitMemberExpression: function (path) {
+		var _this = this;
+		
+		path.replace(_this.getReplacementForMemberExpression(path));
+		
+		return false;
+	},
+	
+	visitCallExpression: function (path) {
+		var _this = this;
+		
+		path.replace(_this.getReplacementForCallExpression(path));
+		
+		_this.traverse(path);
+	},
+	
+	visitFunctionExpression: function (path) {
+		var _this = this;
+		
+		path.replace(_this.getReplacementForFunctionExpression(path));
+		
+		_this.traverse(path);
+	},
+	
+	visitIfStatement: function (path) {
+		var _this = this;
+		
+		if (_this.isLambdaArgumentCheck(path)) {
+			return false;
+		}
+		
+		_this.traverse(path);
+	}
+});
+
+
+function createOptions(options) {
+	options = options || {};
+	return {
+		require: options.require || makeRandomIdentifierName('__require'),
+		console: options.console || makeRandomIdentifierName('__console'),
+		ret: options.ret || makeRandomIdentifierName('__ret'),
+		globals: extend({}, options.globals || {}),
+		lambdas: extend({}, options.lambdas || {})
+	};
+}
+
+function transformAST(ast, options) {
+	options = createOptions(options);
+	
+	var transformer = new Transformer(options);
+	
+	types.visit(ast, transformer);
+	
+	return ast;
+}
+
+function transformCode(code, options) {
+	// Parse and transform the AST, then compile back into the source code.
+	var ast = recast.parse(code);
+	
+	ast = transformAST(ast, options);
+	
+	var code = recast.prettyPrint(ast).code;
+	
+	return code;
+}
+
+
+exports.createOptions = createOptions;
+exports.makeRandomIdentifierName = makeRandomIdentifierName;
+exports.transformAST = transformAST;
+exports.transformCode = transformCode;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "commander": "^2.6.0",
+    "contextify": "^0.1.13",
     "recast": "^0.10.4",
     "when": "^3.7.2"
   },

--- a/test/bricks-json.test.js
+++ b/test/bricks-json.test.js
@@ -1,0 +1,90 @@
+var assert = require('assert');
+
+var inspect = require('util').inspect;
+
+describe('bricks-json', function () {
+	var api = require('../lib/bricks-json');
+	
+	it('should export `JSON` function', function () {
+		assert.equal('function', typeof api.JSON);
+	});
+	
+	it('should export `ParseJSON` function', function () {
+		assert.equal('function', typeof api.ParseJSON);
+	});
+	
+	it('should export `Serializable` function', function () {
+		assert.equal('function', typeof api.Serializable);
+	});
+	
+	describe('`JSON`', function () {
+		it('should serialize a serializable into JSON', function () {
+			function TestObject() {
+				function InnerObject() {
+					api.Serializable.call(this);
+					
+					this.key = "value";
+				}
+				
+				api.Serializable.call(this);
+				
+				this.object = new InnerObject();
+				this.array = [ 1, 2, 3 ];
+			}
+			
+			var object = new TestObject();
+			var expected = '{"value0":{"object":{"key":"value"},"array":[1,2,3]}}';
+			var actual = api.JSON(object);
+			
+			assert.strictEqual(expected, actual);
+		});
+		
+		it('should throw for non-serializable', function () {
+			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
+			
+			assert.throws(function () {
+				api.JSON(object);
+			});
+		});
+		
+		it('should serialize under the passed root name', function () {
+			function TestObject() {
+				api.Serializable.call(this);
+			}
+			
+			var object = new TestObject();
+			var expected = '{"test_name":{}}';
+			var actual = api.JSON(object, "test_name");
+			
+			assert.strictEqual(expected, actual);
+		});
+		
+		it('should ignore non-serializable properties', function () {
+			function TestObject() {
+				api.Serializable.call(this);
+				
+				this.non_serializable_object = {
+					"key": "value"
+				};
+				
+				this.non_serializable_function = function () {};
+			}
+			
+			var object = new TestObject();
+			var expected = '{"value0":{}}';
+			var actual = api.JSON(object);
+			
+			assert.strictEqual(expected, actual);
+		});
+	});
+	
+	describe('`ParseJSON`', function () {
+		it('should parse JSON into a serializable', function () {
+			var json = '{"object":{"key":"value"},"array":[1,2,3]}';
+			var expected = { object: { key: "value" }, array: [ 1, 2, 3 ] };
+			var actual = api.ParseJSON(json);
+			assert.deepEqual(expected, actual);
+			assert.equal('function', typeof actual.serialize);
+		});
+	});
+});

--- a/test/bricks-net-api.test.js
+++ b/test/bricks-net-api.test.js
@@ -108,27 +108,31 @@ describe('bricks-net-api', function () {
 	});
 	
 	describe('`JSON`', function () {
-		it('should serialize into JSON asynchronously', function (done) {
+		it('should serialize a serializable into JSON', function () {
 			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
-			when(
+			object.serialize = function () {
+				return object;
+			};
+			var expected = '{"object":{"key":"value"},"array":[1,2,3]}';
+			var actual = api.JSON(object);
+			assert.strictEqual(expected, actual);
+		});
+		
+		it('should throw for non-serializable', function () {
+			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
+			assert.throws(function () {
 				api.JSON(object)
-			).then(function (result) {
-				assert.strictEqual('{"object":{"key":"value"},"array":[1,2,3]}', result);
-				done();
-			}).done(undefined, done);
+			});
 		});
 	});
 	
 	describe('`ParseJSON`', function () {
-		it('should parse JSON asynchronously', function (done) {
-			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
+		it('should parse JSON into a serializable', function () {
 			var json = '{"object":{"key":"value"},"array":[1,2,3]}';
-			when(
-				api.ParseJSON(json)
-			).then(function (result) {
-				assert.deepEqual(object, result);
-				done();
-			}).done(undefined, done);
+			var expected = { object: { key: "value" }, array: [ 1, 2, 3] };
+			var actual = api.ParseJSON(json);
+			assert.deepEqual(expected, actual);
+			assert.equal('function', typeof actual.serialize);
 		});
 	});
 	

--- a/test/bricks-net-api.test.js
+++ b/test/bricks-net-api.test.js
@@ -107,33 +107,6 @@ describe('bricks-net-api', function () {
 		});
 	});
 	
-	describe('`JSON`', function () {
-		it('should serialize a serializable into JSON', function () {
-			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
-			require('../lib/bricks-json').Serializable.call(object);
-			var expected = '{"object":{"key":"value"},"array":[1,2,3]}';
-			var actual = api.JSON(object);
-			assert.strictEqual(expected, actual);
-		});
-		
-		it('should throw for non-serializable', function () {
-			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
-			assert.throws(function () {
-				api.JSON(object)
-			});
-		});
-	});
-	
-	describe('`ParseJSON`', function () {
-		it('should parse JSON into a serializable', function () {
-			var json = '{"object":{"key":"value"},"array":[1,2,3]}';
-			var expected = { object: { key: "value" }, array: [ 1, 2, 3] };
-			var actual = api.ParseJSON(json);
-			assert.deepEqual(expected, actual);
-			assert.equal('function', typeof actual.serialize);
-		});
-	});
-	
 	describe('`GET`', function () {
 		it('should create an instance of `GET` class', function () {
 			assert.equal(true, api.GET("url") instanceof api.GET);

--- a/test/bricks-net-api.test.js
+++ b/test/bricks-net-api.test.js
@@ -14,47 +14,47 @@ describe('bricks-net-api', function () {
 	
 	it('should export `DefaultContentType` function', function () {
 		assert.equal('function', typeof api.DefaultContentType);
-		assert.equal('// KnowSheet Bricks DefaultContentType', inspect(api.DefaultContentType).toString());
+		assert.equal('// KnowSheet Bricks DefaultContentType.', inspect(api.DefaultContentType).toString());
 	});
 	
 	it('should export `HTTPHeaders` function', function () {
 		assert.equal('function', typeof api.HTTPHeaders);
-		assert.equal('// KnowSheet Bricks HTTPHeaders', inspect(api.HTTPHeaders).toString());
+		assert.equal('// KnowSheet Bricks HTTPHeaders.', inspect(api.HTTPHeaders).toString());
 	});
 	
 	it('should export `HTTPResponse` function', function () {
 		assert.equal('function', typeof api.HTTPResponse);
-		assert.equal('// KnowSheet Bricks HTTPResponse', inspect(api.HTTPResponse).toString());
+		assert.equal('// KnowSheet Bricks HTTPResponse.', inspect(api.HTTPResponse).toString());
 	});
 	
 	it('should export `GET` function', function () {
 		assert.equal('function', typeof api.GET);
-		assert.equal('// KnowSheet Bricks GET', inspect(api.GET).toString());
+		assert.equal('// KnowSheet Bricks GET.', inspect(api.GET).toString());
 	});
 	
 	it('should export `POST` function', function () {
 		assert.equal('function', typeof api.POST);
-		assert.equal('// KnowSheet Bricks POST', inspect(api.POST).toString());
+		assert.equal('// KnowSheet Bricks POST.', inspect(api.POST).toString());
 	});
 	
 	it('should export `POSTFromFile` function', function () {
 		assert.equal('function', typeof api.POSTFromFile);
-		assert.equal('// KnowSheet Bricks POSTFromFile', inspect(api.POSTFromFile).toString());
+		assert.equal('// KnowSheet Bricks POSTFromFile.', inspect(api.POSTFromFile).toString());
 	});
 	
 	it('should export `HTTP` function', function () {
 		assert.equal('function', typeof api.HTTP);
-		assert.equal('// KnowSheet Bricks HTTP', inspect(api.HTTP).toString());
+		assert.equal('// KnowSheet Bricks HTTP.', inspect(api.HTTP).toString());
 	});
 	
 	it('should export `JSON` function', function () {
 		assert.equal('function', typeof api.JSON);
-		assert.equal('// KnowSheet Bricks JSON', inspect(api.JSON).toString());
+		assert.equal('// KnowSheet Bricks JSON.', inspect(api.JSON).toString());
 	});
 	
 	it('should export `ParseJSON` function', function () {
 		assert.equal('function', typeof api.ParseJSON);
-		assert.equal('// KnowSheet Bricks ParseJSON', inspect(api.ParseJSON).toString());
+		assert.equal('// KnowSheet Bricks ParseJSON.', inspect(api.ParseJSON).toString());
 	});
 	
 	describe('`DefaultContentType`', function () {
@@ -802,7 +802,7 @@ describe('bricks-net-api', function () {
 				assert.equal('function', typeof server.ResetAllHandlers);
 				assert.equal('function', typeof server.HandlersCount);
 				assert.strictEqual(0, server.HandlersCount());
-				assert.equal('// KnowSheet Bricks HTTPServer at port ' + serverPort, inspect(server).toString());
+				assert.equal('// KnowSheet Bricks HTTPServer at port ' + serverPort + '.', inspect(server).toString());
 				done();
 			}).done(undefined, done);
 		});

--- a/test/bricks-net-api.test.js
+++ b/test/bricks-net-api.test.js
@@ -110,9 +110,7 @@ describe('bricks-net-api', function () {
 	describe('`JSON`', function () {
 		it('should serialize a serializable into JSON', function () {
 			var object = { object: { key: "value" }, array: [ 1, 2, 3] };
-			object.serialize = function () {
-				return object;
-			};
+			require('../lib/bricks-json').Serializable.call(object);
 			var expected = '{"object":{"key":"value"},"array":[1,2,3]}';
 			var actual = api.JSON(object);
 			assert.strictEqual(expected, actual);

--- a/test/bricks-net-api.test.js
+++ b/test/bricks-net-api.test.js
@@ -871,7 +871,16 @@ describe('bricks-net-api', function () {
 				server.ResetAllHandlers();
 				assert.strictEqual(0, server.HandlersCount());
 				
-				// TODO(sompylasar): Verify the handler functions were removed.
+				// Verify the handler functions were removed.
+				assert.throws(function () {
+					server.UnRegister('/test1');
+				});
+				assert.throws(function () {
+					server.UnRegister('/test2');
+				});
+				assert.throws(function () {
+					server.UnRegister('/test3');
+				});
 				
 				done();
 			}).done(undefined, done);

--- a/test/cpp-arguments.test.js
+++ b/test/cpp-arguments.test.js
@@ -29,13 +29,13 @@ describe('cpp-arguments', function () {
 				'int': 123,
 				'double': 0.5,
 				'object': new TestObject(),
-				'plainObject': { test: { something: "foo" } }
+				'plainObject': {}
 			};
 			var baseAssertionsNegative = {
 				'bool': "abc",
 				'string': 123,
 				'int': 0.5,
-				'double': { test: { something: "foo" } },
+				'double': {},
 				'object': false,
 				'plainObject': new TestObject()
 			};

--- a/test/cpp-arguments.test.js
+++ b/test/cpp-arguments.test.js
@@ -21,19 +21,23 @@ describe('cpp-arguments', function () {
 	
 	describe('`assertion` function', function () {
 		it('should create assertions for base assertion types', function () {
+			function TestObject() {}
+			
 			var baseAssertions = {
 				'bool': false,
 				'string': "abc",
 				'int': 123,
 				'double': 0.5,
-				'object': { test: { something: "foo" } }
+				'object': new TestObject(),
+				'plainObject': { test: { something: "foo" } }
 			};
 			var baseAssertionsNegative = {
 				'bool': "abc",
 				'string': 123,
 				'int': 0.5,
 				'double': { test: { something: "foo" } },
-				'object': false
+				'object': false,
+				'plainObject': new TestObject()
 			};
 			
 			Object.keys(baseAssertions).forEach(function (assertionName) {

--- a/test/promise-transforms.test.js
+++ b/test/promise-transforms.test.js
@@ -368,7 +368,6 @@ describe('promise-transforms', function () {
 		'');
 		var actual = transforms.transformCode(source, extend(extend({}, transformOptions), {
 			globals: {
-				"GlobalFn": "GlobalFn",
 				"SyntaxError": "__SyntaxError",
 				"HTTP": "HTTP",
 				"GET": "GET",

--- a/test/promise-transforms.test.js
+++ b/test/promise-transforms.test.js
@@ -1,0 +1,384 @@
+var assert = require('assert');
+
+var recast = require('recast');
+
+var extend = require('../lib/extend');
+
+function prettyPrint(code) {
+	return recast.prettyPrint(recast.parse(code)).code;
+}
+
+function assertTransformed(source, expected, actual) {
+	source = prettyPrint(source);
+	expected = prettyPrint(expected);
+	actual = prettyPrint(actual);
+	
+	assert.strictEqual(
+		expected,
+		actual,
+		'\n' +
+		'## Source:\n' + source + '\n\n' +
+		'## Expected:\n' + expected + '\n\n' +
+		'## Actual:\n' + actual + '\n\n'
+	);
+	
+	if (process.env.NODE_ENV === 'development') {
+		console.log('\n\n' +
+			'## Source:\n' + source + '\n\n' +
+			'## OK:\n' + actual + '\n'
+		);
+	}
+}
+
+describe('promise-transforms', function () {
+	var transforms = require('../lib/promise-transforms');
+	var transformOptions = {
+		require: 'require',
+		console: 'console',
+		ret: 'ret'
+	};
+	
+	it('transforms `a` correctly', function () {
+		var source = 'a';
+		var expected = ('' +
+		'	require("when")(a);' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms `a.b` correctly', function () {
+		var source = 'a.b';
+		var expected = ('' +
+		'	require("when")(a)' +
+		'		.then(function (ret) {' +
+		'			return ret.b;' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms `a.b.c` correctly', function () {
+		var source = 'a.b.c';
+		var expected = ('' +
+		'	require("when")(a)' +
+		'		.then(function (ret) {' +
+		'			return ret.b;' +
+		'		})' +
+		'		.then(function (ret) {' +
+		'			return ret.c;' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms `a.b.c.d` correctly', function () {
+		var source = 'a.b.c.d';
+		var expected = ('' +
+		'	require("when")(a)' +
+		'		.then(function (ret) {' +
+		'			return ret.b;' +
+		'		})' +
+		'		.then(function (ret) {' +
+		'			return ret.c;' +
+		'		})' +
+		'		.then(function (ret) {' +
+		'			return ret.d;' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms `a()` correctly', function () {
+		var source = 'a()';
+		var expected = ('' +
+		'	require("when")(a)' +
+		'		.then(function (ret) {' +
+		'			return ret();' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms `a(x)` correctly', function () {
+		var source = 'a(x)';
+		var expected = ('' +
+		'	require("when").join(' +
+		'		require("when")(x)' +
+		'	)' +
+		'		.then(function (args) {' +
+		'			return require("when")(a)' +
+		'				.then(function (ret) {' +
+		'					return ret(args[0]);' +
+		'				});' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms `a(x, y)` correctly', function () {
+		var source = 'a(x, y)';
+		var expected = ('' +
+		'	require("when").join(' +
+		'		require("when")(x),' +
+		'		require("when")(y)' +
+		'	)' +
+		'		.then(function (args) {' +
+		'			return require("when")(a)' +
+		'				.then(function (ret) {' +
+		'					return ret(args[0], args[1]);' +
+		'				});' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms `a(1, "2")` correctly', function () {
+		var source = 'a(1, "2")';
+		var expected = ('' +
+		'	require("when")(a)' +
+		'		.then(function (ret) {' +
+		'			return ret(1, "2");' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms `a.b()` correctly', function () {
+		var source = 'a.b()';
+		var expected = ('' +
+		'	require("when")(a)' +
+		'		.then(function (ret) {' +
+		'			return ret.b.bind(ret);' +
+		'		})' +
+		'		.then(function (ret) {' +
+		'			return ret();' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms `a.b().c` correctly', function () {
+		var source = 'a.b().c';
+		var expected = ('' +
+		'	require("when")(a)' +
+		'		.then(function (ret) {' +
+		'			return ret.b.bind(ret);' +
+		'		})' +
+		'		.then(function (ret) {' +
+		'			return ret();' +
+		'		})' +
+		'		.then(function (ret) {' +
+		'			return ret.c;' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms `a.b().c()` correctly', function () {
+		var source = 'a.b().c()';
+		var expected = ('' +
+		'	require("when")(a)' +
+		'		.then(function (ret) {' +
+		'			return ret.b.bind(ret);' +
+		'		})' +
+		'		.then(function (ret) {' +
+		'			return ret();' +
+		'		})' +
+		'		.then(function (ret) {' +
+		'			return ret.c.bind(ret);' +
+		'		})' +
+		'		.then(function (ret) {' +
+		'			return ret();' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms `a.b(x, y)` correctly', function () {
+		var source = 'a.b(x, y)';
+		var expected = ('' +
+		'	require("when").join(' +
+		'		require("when")(x),' +
+		'		require("when")(y)' +
+		'	)' +
+		'		.then(function (args) {' +
+		'			return require("when")(a)' +
+		'				.then(function (ret) {' +
+		'					return ret.b.bind(ret);' +
+		'				})' +
+		'				.then(function (ret) {' +
+		'					return ret(args[0], args[1]);' +
+		'				});' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms `a.b(x, y).c` correctly', function () {
+		var source = 'a.b(x, y).c';
+		var expected = ('' +
+		'	require("when").join(' +
+		'		require("when")(x),' +
+		'		require("when")(y)' +
+		'	)' +
+		'		.then(function (args) {' +
+		'			return require("when")(a)' +
+		'				.then(function (ret) {' +
+		'					return ret.b.bind(ret);' +
+		'				})' +
+		'				.then(function (ret) {' +
+		'					return ret(args[0], args[1]);' +
+		'				});' +
+		'		})' +
+		'		.then(function (ret) {' +
+		'			return ret.c;' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms `a.b(1, "2").c` correctly', function () {
+		var source = 'a.b(1, "2").c';
+		var expected = ('' +
+		'	require("when")(a)' +
+		'		.then(function (ret) {' +
+		'			return ret.b.bind(ret);' +
+		'		})' +
+		'		.then(function (ret) {' +
+		'			return ret(1, "2");' +
+		'		})' +
+		'		.then(function (ret) {' +
+		'			return ret.c;' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, transformOptions);
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms code with function calls correctly', function () {
+		var source = ('' +
+		'	HTTP(GET("localhost:2015/test?a=b"))' +
+		'');
+		var expected = ('' +
+		'	require("when").join(' +
+		'		require("when")(GET("localhost:2015/test?a=b"))' +
+		'	).then(function (args) {' +
+		'		return HTTP(args[0]);' +
+		'	})' +
+		'');
+		
+		var actual = transforms.transformCode(source, extend(extend({}, transformOptions), {
+			globals: {
+				"HTTP": "HTTP",
+				"GET": "GET"
+			}
+		}));
+		
+		assertTransformed(source, expected, actual);
+	});
+	
+	it('transforms code with a lambda correctly', function () {
+		var source = ('' +
+		'	HTTP(2015).Register("/test", __lambda = function __lambda(r) {' +
+		'		if (r === undefined) {' +
+		'			throw __SyntaxError("Argument \\"r\\" missing from the call to [](Request r).");' +
+		'		}' +
+		'		r(JSON(r.url.ComposeURL()));' +
+		'	});' +
+		'');
+		var expected = ('' +
+		// HTTP(2015)
+		'	require("when")(HTTP(2015))' +
+		// HTTP(2015).Register
+		'		.then(function (ret) {' +
+		'			return ret.Register.bind(ret);' +
+		'		})' +
+		// HTTP(2015).Register("/test", ...)
+		'		.then(function (ret) {' +
+		'			return ret("/test", __lambda = function __lambda(r) {' +
+		'				return require("when/sequence")([' +
+		'					function () {' +
+		'						if (r === undefined) {' +
+		'							throw __SyntaxError("Argument \\"r\\" missing from the call to [](Request r).");' +
+		'						}' +
+		'					},' +
+		'					function () {' +
+		// r(...)
+		'						return require("when").join(' +
+		// JSON(...)
+		'							require("when").join(' +
+		//     r
+		'								require("when")(r)' +
+		//     -> r.url
+		'									.then(function (ret) {' +
+		'										return ret.url;' +
+		'									})' +
+		//     -> r.url.ComposeURL
+		'									.then(function (ret) {' +
+		'										return ret.ComposeURL.bind(ret);' +
+		'									})' +
+		//     -> r.url.ComposeURL()
+		'									.then(function (ret) {' +
+		'										return ret();' +
+		'									})' +
+		'							)' +
+		'							.then(function (args) {' +
+		// -> JSON(...)
+		'								return JSON(args[0]);' +
+		'							})' +
+		'						)' +
+		'						.then(function (args) {' +
+		// -> r(...)
+		'							return require("when")(r)' +
+		'								.then(function (ret) {' +
+		'									return ret(args[0]);' +
+		'								});' +
+		'						})' +
+		'					}' +
+		'				]);' +
+		'			});' +
+		'		});' +
+		'');
+		var actual = transforms.transformCode(source, extend(extend({}, transformOptions), {
+			globals: {
+				"GlobalFn": "GlobalFn",
+				"SyntaxError": "__SyntaxError",
+				"HTTP": "HTTP",
+				"GET": "GET",
+				"JSON": "JSON"
+			},
+			lambdas: {
+				"__lambda": "__lambda"
+			}
+		}));
+		
+		assertTransformed(source, expected, actual);
+	});
+});


### PR DESCRIPTION
- Moved transpiling logic into a separate module `"promise-transforms"`.
- Added tests for transpiling various expressions.
- Switched to use `"contextify"` for code evaluation (native `"vm"`
  also works in the current state, so kept both variants under a
  `USE_CONTEXTIFY` flag).
- HTTPServer: Fixed broken promise chain (unhandled rejection in
  `destroy`).
- This PR includes #9.
